### PR TITLE
Fix duration parsing failure on .part files with duplicated MOOV atom

### DIFF
--- a/backend/video_duration.go
+++ b/backend/video_duration.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"time"
 
 	ffmpeg "github.com/u2takey/ffmpeg-go"
 )
+
+var durationLineRegex = regexp.MustCompile(`Duration:\s+(\d+):(\d+):(\d+(?:\.\d+)?)`)
 
 type VideoDuration struct {
 	cfg       *Config
@@ -35,17 +39,31 @@ func (vd *VideoDuration) get(videoPath string, force bool) (float64, error) {
 		}
 	}
 
-	probeJSON, err := ffmpeg.ProbeWithTimeout(videoPath, 45*time.Second, ffmpeg.KwArgs{})
-	if err != nil {
-		return 0, err
+	probeJSON, probeErr := ffmpeg.ProbeWithTimeout(videoPath, 5*time.Second, ffmpeg.KwArgs{})
+	if probeErr == nil {
+		var probe struct {
+			Format struct {
+				Duration string `json:"duration"`
+			} `json:"format"`
+		}
+		if err := json.Unmarshal([]byte(probeJSON), &probe); err != nil {
+			return 0, err
+		}
+		return strconv.ParseFloat(probe.Format.Duration, 64)
 	}
-	var probe struct {
-		Format struct {
-			Duration string `json:"duration"`
-		} `json:"format"`
+
+	// ffprobe may exit with non-zero (e.g. duplicated MOOV atom on .part files)
+	// but still emit duration in its output — try to parse it from the error string
+	matches := durationLineRegex.FindStringSubmatch(probeErr.Error())
+	if matches == nil {
+		return 0, probeErr
 	}
-	if err := json.Unmarshal([]byte(probeJSON), &probe); err != nil {
-		return 0, err
+	h, _ := strconv.ParseFloat(matches[1], 64)
+	m, _ := strconv.ParseFloat(matches[2], 64)
+	s, _ := strconv.ParseFloat(matches[3], 64)
+	total := h*3600 + m*60 + s
+	if total == 0 {
+		return 0, fmt.Errorf("parsed zero duration from error output: %w", probeErr)
 	}
-	return strconv.ParseFloat(probe.Format.Duration, 64)
+	return total, nil
 }

--- a/backend/video_ios_validator.go
+++ b/backend/video_ios_validator.go
@@ -25,7 +25,7 @@ func NewVideoIOSValidator() *VideoIOSValidator {
 // which causes iOS to refuse playback.
 // A working file has has_b_frames=0 and a valid sample_aspect_ratio like "1:1".
 func (v *VideoIOSValidator) Validate(videoPath string) (VideoIOSValidation, error) {
-	probeJSON, err := ffmpeg.ProbeWithTimeout(videoPath, 15*time.Second, ffmpeg.KwArgs{})
+	probeJSON, err := ffmpeg.ProbeWithTimeout(videoPath, 5*time.Second, ffmpeg.KwArgs{})
 	if err != nil {
 		return VideoIOSValidation{}, err
 	}


### PR DESCRIPTION
## Summary
- When ffprobe exits with non-zero status (e.g. duplicated MOOV atom on `.part` files), fall back to parsing the `Duration:` line from the error output instead of returning an error immediately
- Reduced probe timeout from 45s → 5s in `video_duration.go` and from 15s → 5s in `video_ios_validator.go`

## Test plan
- [x] Download a video that produces `.part` files and verify duration is reported correctly instead of error
- [x] Verify normal (non-part) files still return correct duration

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)