### PR TITLE
Delete original videos instead of moving them to original folder

### DIFF
--- a/backend/fix_ios_worker.go
+++ b/backend/fix_ios_worker.go
@@ -91,12 +91,7 @@ func (fw *FixIOSWorker) fix(videoPath string, bitrate int64) error {
 		return err
 	}
 
-	originalDir := filepath.Join(filepath.Dir(videoPath), "original")
-	if err := os.MkdirAll(originalDir, 0755); err != nil {
-		_ = os.Remove(tmpPath)
-		return err
-	}
-	if err := os.Rename(videoPath, filepath.Join(originalDir, filepath.Base(videoPath))); err != nil {
+	if err := os.Remove(videoPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return err
 	}

--- a/backend/video_splitter.go
+++ b/backend/video_splitter.go
@@ -36,9 +36,5 @@ func (vs *VideoSplitter) Split(videoPath string, splitDuration float64) error {
 		return fmt.Errorf("%w: %s", err, stderr.String())
 	}
 
-	originalDir := filepath.Join(filepath.Dir(videoPath), "original")
-	if err := os.MkdirAll(originalDir, 0755); err != nil {
-		return err
-	}
-	return os.Rename(videoPath, filepath.Join(originalDir, filepath.Base(videoPath)))
+	return os.Remove(videoPath)
 }


### PR DESCRIPTION
## Summary
- In `fix_ios_worker.go`: delete the original video file instead of moving it to an `original/` subdirectory before replacing with the iOS-fixed version
- In `video_splitter.go`: delete the original video file instead of moving it to an `original/` subdirectory after splitting

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)