### PR TITLE
Route yt-dlp output through loguru logger with datetime

### DIFF
--- a/backend/fix_ios_worker.go
+++ b/backend/fix_ios_worker.go
@@ -82,7 +82,6 @@ func (fw *FixIOSWorker) fix(videoPath string, bitrate int64) error {
 			"c:a":       "copy",
 			"movflags":  "+faststart",
 		}).
-		OverWriteOutput().
 		Compile()
 
 	cmd.Stderr = os.Stderr

--- a/backend/video_splitter.go
+++ b/backend/video_splitter.go
@@ -27,7 +27,6 @@ func (vs *VideoSplitter) Split(videoPath string, splitDuration float64) error {
 			"reset_timestamps":     1,
 			"segment_start_number": 1,
 		}).
-		OverWriteOutput().
 		Compile()
 
 	var stderr bytes.Buffer

--- a/downloader/downloader_module.py
+++ b/downloader/downloader_module.py
@@ -2,6 +2,8 @@ import os
 import tomllib
 
 from dotenv import load_dotenv
+from typing import Callable
+
 from injector import Module, provider, singleton, SingletonScope
 
 from channel_poller import ChannelPoller
@@ -23,7 +25,6 @@ class DownloaderModule(Module):
         load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
         with open(os.path.join(os.path.dirname(__file__), "config.toml"), "rb") as f:
             binder.bind(Config, to=Config(tomllib.load(f)))
-        binder.bind(YtDlpLogger, to=YtDlpLogger, scope=SingletonScope)
         binder.bind(YoutubeMetadataProvider, to=YoutubeMetadataProvider, scope=SingletonScope)
         binder.bind(TwitchMetadataProvider, to=TwitchMetadataProvider, scope=SingletonScope)
         binder.bind(YoutubeLiveDownloader, to=YoutubeLiveDownloader, scope=SingletonScope)
@@ -32,6 +33,11 @@ class DownloaderModule(Module):
         binder.bind(FibonacciSleepFactory, to=FibonacciSleepFactory, scope=SingletonScope)
         binder.bind(ChannelPoller, to=ChannelPoller, scope=SingletonScope)
         binder.bind(MultiChannelPoller, to=MultiChannelPoller, scope=SingletonScope)
+
+    @provider
+    @singleton
+    def yt_dlp_logger_factory(self) -> Callable[[], YtDlpLogger]:
+        return YtDlpLogger
 
     @provider
     @singleton

--- a/downloader/twitch_downloader.py
+++ b/downloader/twitch_downloader.py
@@ -20,6 +20,9 @@ class TwitchDownloader(Downloader):
         if not url:
             raise ValueError("url is required")
 
+        def _retry_sleep(n):  # noqa: ARG001
+            return 15
+
         def sync():
             ydl_opts = {
                 "logger": self._yt_dlp_logger,
@@ -37,10 +40,10 @@ class TwitchDownloader(Downloader):
                 "file_access_retries": 10,  # Local disk/NAS access retries
                 # Sleep between each retry attempt (all retry types)
                 "retry_sleep_functions": {
-                    "http": lambda _: 15,
-                    "fragment": lambda _: 15,
-                    "file_access": lambda _: 15,
-                    "extractor": lambda _: 15,
+                    "http": _retry_sleep,
+                    "fragment": _retry_sleep,
+                    "file_access": _retry_sleep,
+                    "extractor": _retry_sleep,
                 },
                 # --- Precise Timing Control ---
                 "sleep_interval": 15,  # Seconds to wait between download tasks

--- a/downloader/twitch_downloader.py
+++ b/downloader/twitch_downloader.py
@@ -48,6 +48,8 @@ class TwitchDownloader(Downloader):
                 "sleep_requests": 5,  # Wait 5s between finding info for each video
                 # --- Safety Buffers ---
                 "socket_timeout": 30,  # Wait 30s before considering a socket "dead"
+                # Suppress FFmpeg's direct stderr output (it bypasses yt-dlp's logger)
+                "postprocessor_args": {"ffmpeg": ["-loglevel", "warning"]},
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 ydl.download([url])

--- a/downloader/twitch_downloader.py
+++ b/downloader/twitch_downloader.py
@@ -8,6 +8,7 @@ from injector import inject
 from config import Config
 from downloader import Downloader
 from yt_dlp_logger import YtDlpLogger
+from yt_dlp_settings import SHARED_YT_DLP_SETTINGS
 
 
 class TwitchDownloader(Downloader):
@@ -20,11 +21,9 @@ class TwitchDownloader(Downloader):
         if not url:
             raise ValueError("url is required")
 
-        def _retry_sleep(n):  # noqa: ARG001
-            return 15
-
         def sync():
             ydl_opts = {
+                **SHARED_YT_DLP_SETTINGS,
                 "logger": self._yt_dlp_logger,
                 "format": "best",
                 "merge_output_format": "mp4",
@@ -33,24 +32,6 @@ class TwitchDownloader(Downloader):
                     self._config["output_folder"],
                     "[%(uploader)s] %(title)s.%(ext)s",
                 ),
-                # --- The Retry Trio ---
-                "retries": 10,  # Generic network retries
-                "fragment_retries": 10,  # Video chunk/fragment retries
-                "extractor_retries": 10,  # Website parsing/scraping retries
-                "file_access_retries": 10,  # Local disk/NAS access retries
-                # Sleep between each retry attempt (all retry types)
-                "retry_sleep_functions": {
-                    "http": _retry_sleep,
-                    "fragment": _retry_sleep,
-                    "file_access": _retry_sleep,
-                    "extractor": _retry_sleep,
-                },
-                # --- Precise Timing Control ---
-                "sleep_interval": 15,  # Seconds to wait between download tasks
-                "max_sleep_interval": 15,  # Keep it strictly at 15s (no randomization)
-                "sleep_requests": 5,  # Wait 5s between finding info for each video
-                # --- Safety Buffers ---
-                "socket_timeout": 30,  # Wait 30s before considering a socket "dead"
                 # Suppress FFmpeg's direct stderr output (it bypasses yt-dlp's logger)
                 "postprocessor_args": {"ffmpeg": ["-loglevel", "warning", "-stats", "-stats_period", "60"]},
                 "external_downloader_args": {"ffmpeg": ["-loglevel", "warning", "-stats", "-stats_period", "60"]},

--- a/downloader/twitch_downloader.py
+++ b/downloader/twitch_downloader.py
@@ -52,7 +52,8 @@ class TwitchDownloader(Downloader):
                 # --- Safety Buffers ---
                 "socket_timeout": 30,  # Wait 30s before considering a socket "dead"
                 # Suppress FFmpeg's direct stderr output (it bypasses yt-dlp's logger)
-                "postprocessor_args": {"ffmpeg": ["-loglevel", "warning"]},
+                "postprocessor_args": {"ffmpeg": ["-loglevel", "warning", "-stats", "-stats_period", "60"]},
+                "external_downloader_args": {"ffmpeg": ["-loglevel", "warning", "-stats", "-stats_period", "60"]},
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 ydl.download([url])

--- a/downloader/twitch_downloader.py
+++ b/downloader/twitch_downloader.py
@@ -35,6 +35,13 @@ class TwitchDownloader(Downloader):
                 "fragment_retries": 10,  # Video chunk/fragment retries
                 "extractor_retries": 10,  # Website parsing/scraping retries
                 "file_access_retries": 10,  # Local disk/NAS access retries
+                # Sleep between each retry attempt (all retry types)
+                "retry_sleep_functions": {
+                    "http": lambda _: 15,
+                    "fragment": lambda _: 15,
+                    "file_access": lambda _: 15,
+                    "extractor": lambda _: 15,
+                },
                 # --- Precise Timing Control ---
                 "sleep_interval": 15,  # Seconds to wait between download tasks
                 "max_sleep_interval": 15,  # Keep it strictly at 15s (no randomization)

--- a/downloader/youtube_live_downloader.py
+++ b/downloader/youtube_live_downloader.py
@@ -8,6 +8,7 @@ from injector import inject
 from config import Config
 from downloader import Downloader
 from yt_dlp_logger import YtDlpLogger
+from yt_dlp_settings import SHARED_YT_DLP_SETTINGS
 
 
 class YoutubeLiveDownloader(Downloader):
@@ -22,11 +23,9 @@ class YoutubeLiveDownloader(Downloader):
         if not url:
             raise ValueError("url is required")
 
-        def _retry_sleep(n):  # noqa: ARG001
-            return 15
-
         def sync():
             ydl_opts = {
+                **SHARED_YT_DLP_SETTINGS,
                 "logger": self._yt_dlp_logger_factory(),
                 "format": "bestvideo+bestaudio/best",
                 # CRITICAL: This flag tells yt-dlp to start from the beginning of the DVR
@@ -36,24 +35,6 @@ class YoutubeLiveDownloader(Downloader):
                 "outtmpl": os.path.join(
                     self._config["output_folder"], "[%(uploader)s] %(title)s.%(ext)s"
                 ),
-                # --- The Retry Trio ---
-                "retries": 10,  # Generic network retries
-                "fragment_retries": 10,  # Video chunk/fragment retries
-                "extractor_retries": 10,  # Website parsing/scraping retries
-                "file_access_retries": 10,  # Local disk/NAS access retries
-                # Sleep between each retry attempt (all retry types)
-                "retry_sleep_functions": {
-                    "http": _retry_sleep,
-                    "fragment": _retry_sleep,
-                    "file_access": _retry_sleep,
-                    "extractor": _retry_sleep,
-                },
-                # --- Precise Timing Control ---
-                "sleep_interval": 15,  # Seconds to wait between download tasks
-                "max_sleep_interval": 15,  # Keep it strictly at 15s (no randomization)
-                "sleep_requests": 5,  # Wait 5s between finding info for each video
-                # --- Safety Buffers ---
-                "socket_timeout": 30,  # Wait 30s before considering a socket "dead"
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 ydl.download([url])

--- a/downloader/youtube_live_downloader.py
+++ b/downloader/youtube_live_downloader.py
@@ -3,8 +3,8 @@ import os
 
 import yt_dlp
 
+from typing import Callable
 from injector import inject
-
 from config import Config
 from downloader import Downloader
 from yt_dlp_logger import YtDlpLogger
@@ -12,9 +12,11 @@ from yt_dlp_logger import YtDlpLogger
 
 class YoutubeLiveDownloader(Downloader):
     @inject
-    def __init__(self, config: Config, yt_dlp_logger: YtDlpLogger):
+    def __init__(
+        self, config: Config, yt_dlp_logger_factory: Callable[[], YtDlpLogger]
+    ):
         self._config = config
-        self._yt_dlp_logger = yt_dlp_logger
+        self._yt_dlp_logger_factory = yt_dlp_logger_factory
 
     async def download(self, url: str) -> None:
         if not url:
@@ -22,7 +24,7 @@ class YoutubeLiveDownloader(Downloader):
 
         def sync():
             ydl_opts = {
-                "logger": self._yt_dlp_logger,
+                "logger": self._yt_dlp_logger_factory(),
                 "format": "bestvideo+bestaudio/best",
                 # CRITICAL: This flag tells yt-dlp to start from the beginning of the DVR
                 "live_from_start": True,

--- a/downloader/youtube_live_downloader.py
+++ b/downloader/youtube_live_downloader.py
@@ -38,6 +38,13 @@ class YoutubeLiveDownloader(Downloader):
                 "fragment_retries": 10,  # Video chunk/fragment retries
                 "extractor_retries": 10,  # Website parsing/scraping retries
                 "file_access_retries": 10,  # Local disk/NAS access retries
+                # Sleep between each retry attempt (all retry types)
+                "retry_sleep_functions": {
+                    "http": lambda _: 15,
+                    "fragment": lambda _: 15,
+                    "file_access": lambda _: 15,
+                    "extractor": lambda _: 15,
+                },
                 # --- Precise Timing Control ---
                 "sleep_interval": 15,  # Seconds to wait between download tasks
                 "max_sleep_interval": 15,  # Keep it strictly at 15s (no randomization)

--- a/downloader/youtube_live_downloader.py
+++ b/downloader/youtube_live_downloader.py
@@ -22,6 +22,9 @@ class YoutubeLiveDownloader(Downloader):
         if not url:
             raise ValueError("url is required")
 
+        def _retry_sleep(n):  # noqa: ARG001
+            return 15
+
         def sync():
             ydl_opts = {
                 "logger": self._yt_dlp_logger_factory(),
@@ -29,7 +32,7 @@ class YoutubeLiveDownloader(Downloader):
                 # CRITICAL: This flag tells yt-dlp to start from the beginning of the DVR
                 "live_from_start": True,
                 "merge_output_format": "mp4",
-                "overwrites": True,
+                "overwrites": False,
                 "outtmpl": os.path.join(
                     self._config["output_folder"], "[%(uploader)s] %(title)s.%(ext)s"
                 ),
@@ -40,10 +43,10 @@ class YoutubeLiveDownloader(Downloader):
                 "file_access_retries": 10,  # Local disk/NAS access retries
                 # Sleep between each retry attempt (all retry types)
                 "retry_sleep_functions": {
-                    "http": lambda _: 15,
-                    "fragment": lambda _: 15,
-                    "file_access": lambda _: 15,
-                    "extractor": lambda _: 15,
+                    "http": _retry_sleep,
+                    "fragment": _retry_sleep,
+                    "file_access": _retry_sleep,
+                    "extractor": _retry_sleep,
                 },
                 # --- Precise Timing Control ---
                 "sleep_interval": 15,  # Seconds to wait between download tasks

--- a/downloader/yt_dlp_logger.py
+++ b/downloader/yt_dlp_logger.py
@@ -12,15 +12,17 @@ class YtDlpLogger:
         self._log = logger.bind(streamer="-")
         self._progress_buffer: list[str] = []
 
+    # Stack when called directly (no _buffer_or_log layer):
+    #   [0] _depth  [1] debug  [2] yt-dlp caller  → start=2
     def debug(self, msg):
         if msg.startswith("[debug] "):
-            self._log.opt(depth=self._depth()).debug(msg)
+            self._log.opt(depth=self._depth(2)).debug(msg)
         else:
             self._buffer_or_log(msg)
 
-    def _depth(self):
+    def _depth(self, start=3):
         stack = inspect.stack()
-        for i, frame in enumerate(stack[2:], start=2):
+        for i, frame in enumerate(stack[start:], start=start):
             if frame.function not in ("to_screen", "to_stderr"):
                 return i - 1
         return 1
@@ -30,18 +32,22 @@ class YtDlpLogger:
             self._progress_buffer.append(msg)
             if len(self._progress_buffer) >= DOWNLOAD_PROGRESS_BUFFER_SIZE:
                 last = self._progress_buffer[-1]
-                self._log.opt(depth=self._depth()).info(
+                self._log.opt(depth=self._depth(3)).info(
                     f"{DOWNLOAD_PROGRESS_BUFFER_SIZE} more messages like: {last}"
                 )
                 self._progress_buffer.clear()
         else:
-            self._log.opt(depth=self._depth()).info(msg)
+            self._log.opt(depth=self._depth(3)).info(msg)
 
+    # Stack when called via _buffer_or_log:
+    #   [0] _depth  [1] _buffer_or_log  [2] info  [3] yt-dlp caller  → start=3
     def info(self, msg):
         self._buffer_or_log(msg)
 
+    # Stack when called directly (no _buffer_or_log layer):
+    #   [0] _depth  [1] warning/error  [2] yt-dlp caller  → start=2
     def warning(self, msg):
-        self._log.opt(depth=self._depth()).warning(msg)
+        self._log.opt(depth=self._depth(2)).warning(msg)
 
     def error(self, msg):
-        self._log.opt(depth=self._depth()).error(msg)
+        self._log.opt(depth=self._depth(2)).error(msg)

--- a/downloader/yt_dlp_settings.py
+++ b/downloader/yt_dlp_settings.py
@@ -1,0 +1,24 @@
+def _retry_sleep(n):  # noqa: ARG001
+    return 15
+
+
+SHARED_YT_DLP_SETTINGS = {
+    # --- The Retry Trio ---
+    "retries": 10,  # Generic network retries
+    "fragment_retries": 10,  # Video chunk/fragment retries
+    "extractor_retries": 10,  # Website parsing/scraping retries
+    "file_access_retries": 10,  # Local disk/NAS access retries
+    # Sleep between each retry attempt (all retry types)
+    "retry_sleep_functions": {
+        "http": _retry_sleep,
+        "fragment": _retry_sleep,
+        "file_access": _retry_sleep,
+        "extractor": _retry_sleep,
+    },
+    # --- Precise Timing Control ---
+    "sleep_interval": 15,  # Seconds to wait between download tasks
+    "max_sleep_interval": 15,  # Keep it strictly at 15s (no randomization)
+    "sleep_requests": 5,  # Wait 5s between finding info for each video
+    # --- Safety Buffers ---
+    "socket_timeout": 30,  # Wait 30s before considering a socket "dead"
+}


### PR DESCRIPTION
Closes #9

## Summary
- Route all yt-dlp output through loguru logger via a custom `YtDlpLogger` class
- Inject `YtDlpLogger` via factory so each download gets a fresh instance
- Suppress FFmpeg stderr output that bypasses yt-dlp logger
- Disable overwrite behavior in both FFmpeg and yt-dlp
- Throttle FFmpeg progress output to once per minute
- Add `retry_sleep_functions` to sleep 15s between all retry attempts
- Extract shared yt-dlp settings into `SHARED_YT_DLP_SETTINGS`

## Test plan
- [ ] Verify yt-dlp log output appears in loguru logs with proper datetime formatting
- [ ] Verify FFmpeg output does not leak to stderr bypassing the logger
- [ ] Verify retry attempts sleep 15s between retries
- [ ] Test YouTube, Twitch, and YouTube live downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)