### PR TITLE
Force H.264+AAC download format for iOS compatibility (#4)

### DIFF
--- a/downloader/youtube_video_downloader.py
+++ b/downloader/youtube_video_downloader.py
@@ -27,7 +27,7 @@ class YoutubeVideoDownloader(Downloader):
             ydl_opts = {
                 **SHARED_YT_DLP_SETTINGS,
                 "logger": self._yt_dlp_logger_factory(),
-                "format": "bestvideo+bestaudio/best",
+                "format": "bestvideo[vcodec^=avc1]+bestaudio[acodec^=mp4a]/bestvideo[vcodec^=avc1]+bestaudio/bestvideo+bestaudio/best",
                 "merge_output_format": "mp4",
                 "overwrites": False,
                 "outtmpl": os.path.join(


### PR DESCRIPTION
## Summary
- Changes yt-dlp format selector to prefer `avc1` (H.264) video and `mp4a` (AAC) audio
- Fixes videos downloaded as AV1+Opus (e.g. from YouTube) not playing on iOS devices
- Falls back gracefully: `avc1+mp4a` → `avc1+bestaudio` → `bestvideo+bestaudio` → `best`

## Test plan
- [ ] Download a YouTube video that previously came as AV1+Opus and verify it downloads as H.264+AAC
- [ ] Verify the downloaded file plays on an iOS device
- [ ] Verify downloads still work normally for other URLs

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)