### PR TITLE
Add Rumble video download support (#33)

### DIFF
--- a/backend/download_request_service.go
+++ b/backend/download_request_service.go
@@ -21,7 +21,8 @@ func (s *DownloadRequestService) IsSupportedURL(rawURL string) bool {
 	host := strings.ToLower(u.Host)
 	return strings.Contains(host, "youtube.com") ||
 		strings.Contains(host, "youtu.be") ||
-		strings.Contains(host, "twitch.tv")
+		strings.Contains(host, "twitch.tv") ||
+		strings.Contains(host, "rumble.com")
 }
 
 func (s *DownloadRequestService) ExtractVideoID(rawURL string) (service string, id string, err error) {
@@ -39,6 +40,8 @@ func (s *DownloadRequestService) ExtractVideoID(rawURL string) (service string, 
 		id = strings.Trim(u.Path, "/")
 	} else if strings.Contains(host, "twitch.tv") {
 		service = "twitch"
+	} else if strings.Contains(host, "rumble.com") {
+		service = "rumble"
 	}
 
 	// Generic fallback: last non-empty path segment

--- a/backend/video_reader.go
+++ b/backend/video_reader.go
@@ -28,7 +28,7 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 	splitPartRe := regexp.MustCompile(`^(.+) part\d{2}\.mp4$`)
 	formatRe := regexp.MustCompile(`f\d{3}\.mp4$`)
 	downloadingPartRe := regexp.MustCompile(`\.f\d{3}\.[^.]+\.part$`)
-	fragmentPartRe := regexp.MustCompile(`\.mp4\.part-.+\.part$`)
+	fragmentPartRe := regexp.MustCompile(`\.mp4\.part-(?:Frag)?\d+\.part$`)
 	channelRe := regexp.MustCompile(`^\[([^\]]+)\] ?`)
 	formatSegmentRe := regexp.MustCompile(`\.f\d{3}$`)
 

--- a/backend/video_reader.go
+++ b/backend/video_reader.go
@@ -28,7 +28,7 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 	splitPartRe := regexp.MustCompile(`^(.+) part\d{2}\.mp4$`)
 	formatRe := regexp.MustCompile(`f\d{3}\.mp4$`)
 	downloadingPartRe := regexp.MustCompile(`\.f\d{3}\.[^.]+\.part$`)
-	fragmentPartRe := regexp.MustCompile(`\.f\d{3}\.mp4\.part-.+\.part$`)
+	fragmentPartRe := regexp.MustCompile(`\.mp4\.part-.+\.part$`)
 	channelRe := regexp.MustCompile(`^\[([^\]]+)\] ?`)
 	formatSegmentRe := regexp.MustCompile(`\.f\d{3}$`)
 

--- a/backend/video_reader_test.go
+++ b/backend/video_reader_test.go
@@ -123,6 +123,20 @@ func TestGetVideos_FragmentPartFile_IsSkipped(t *testing.T) {
 	assert.Empty(t, videos)
 }
 
+func TestGetVideos_RumbleDownloadingFiles_ReturnsOnlyMainPartAsDownloading(t *testing.T) {
+	vr := setupVideoReader(t, fstest.MapFS{
+		"video.mp4.part":              &fstest.MapFile{Data: make([]byte, 500)},
+		"video.mp4.part-Frag154.part": &fstest.MapFile{Data: make([]byte, 100)},
+	})
+
+	videos, err := vr.GetVideos()
+
+	require.NoError(t, err)
+	require.Len(t, videos, 1)
+	assert.Equal(t, "video.mp4.part", videos[0].Filename)
+	assert.Equal(t, "Downloading", videos[0].Status)
+}
+
 func TestGetVideos_MixedFiles_ReturnsCorrectVideosAndStatuses(t *testing.T) {
 	vr := setupVideoReader(t, fstest.MapFS{
 		// ready

--- a/downloader/config.toml
+++ b/downloader/config.toml
@@ -13,9 +13,9 @@ mode = "youtube_live"
 id = "UCaTznQhurW5AaiYPbhEA-KA"
 mode = "youtube_live"
 
-[[channels]]
-id = "joshstrifehayes"
-mode = "twitch"
+# [[channels]]
+# id = "joshstrifehayes"
+# mode = "twitch"
 
 # [[channels]]
 # id = "UCI_mwTKUhicNzFrhm33MzBQ"

--- a/downloader/download_request_poller.py
+++ b/downloader/download_request_poller.py
@@ -12,7 +12,7 @@ from downloader_map import DownloaderMap
 SERVICE_TO_DOWNLOADER = {
     "youtube": "youtube_video",
     "twitch": "twitch",
-    "rumble": "twitch",
+    "rumble": "rumble",
 }
 
 DOWNLOAD_FILE_RE = re.compile(r"^video\.([^.]+)\.([^.]+)\.download$")

--- a/downloader/download_request_poller.py
+++ b/downloader/download_request_poller.py
@@ -12,6 +12,7 @@ from downloader_map import DownloaderMap
 SERVICE_TO_DOWNLOADER = {
     "youtube": "youtube_video",
     "twitch": "twitch",
+    "rumble": "twitch",
 }
 
 DOWNLOAD_FILE_RE = re.compile(r"^video\.([^.]+)\.([^.]+)\.download$")

--- a/downloader/downloader_module.py
+++ b/downloader/downloader_module.py
@@ -13,6 +13,7 @@ from downloader_map import DownloaderMap
 from fibonacci_sleep_factory import FibonacciSleepFactory
 from metadata_provider_map import MetadataProviderMap
 from multi_channel_poller import MultiChannelPoller
+from rumble_downloader import RumbleDownloader
 from twitch_downloader import TwitchDownloader
 from twitch_metadata_provider import TwitchMetadataProvider
 from youtube_api_key_pool import YoutubeApiKeyPool
@@ -32,6 +33,7 @@ class DownloaderModule(Module):
         binder.bind(YoutubeLiveDownloader, to=YoutubeLiveDownloader, scope=SingletonScope)
         binder.bind(YoutubeVideoDownloader, to=YoutubeVideoDownloader, scope=SingletonScope)
         binder.bind(TwitchDownloader, to=TwitchDownloader, scope=SingletonScope)
+        binder.bind(RumbleDownloader, to=RumbleDownloader, scope=SingletonScope)
         binder.bind(YoutubeApiKeyPool, to=YoutubeApiKeyPool, scope=SingletonScope)
         binder.bind(FibonacciSleepFactory, to=FibonacciSleepFactory, scope=SingletonScope)
         binder.bind(ChannelPoller, to=ChannelPoller, scope=SingletonScope)
@@ -62,9 +64,11 @@ class DownloaderModule(Module):
         youtube_live: YoutubeLiveDownloader,
         youtube_video: YoutubeVideoDownloader,
         twitch: TwitchDownloader,
+        rumble: RumbleDownloader,
     ) -> DownloaderMap:
         return DownloaderMap({
             "youtube_live": youtube_live,
             "youtube_video": youtube_video,
             "twitch": twitch,
+            "rumble": rumble,
         })

--- a/downloader/multi_channel_poller.py
+++ b/downloader/multi_channel_poller.py
@@ -16,6 +16,6 @@ class MultiChannelPoller:
         await asyncio.gather(
             *[
                 self._poller.poll(ch["id"], mode=ch["mode"])
-                for ch in self._config["channels"]
+                for ch in self._config.get("channels") or []
             ]
         )

--- a/downloader/rumble_downloader.py
+++ b/downloader/rumble_downloader.py
@@ -1,0 +1,49 @@
+import asyncio
+import os
+
+import yt_dlp
+from yt_dlp.networking.impersonate import ImpersonateTarget
+
+from injector import inject
+
+from config import Config
+from downloader import Downloader
+from yt_dlp_logger import YtDlpLogger
+from yt_dlp_settings import SHARED_YT_DLP_SETTINGS
+
+
+class RumbleDownloader(Downloader):
+    @inject
+    def __init__(self, config: Config, yt_dlp_logger: YtDlpLogger):
+        self._config = config
+        self._yt_dlp_logger = yt_dlp_logger
+
+    async def download(self, url: str) -> None:
+        if not url:
+            raise ValueError("url is required")
+
+        def sync():
+            ydl_opts = {
+                **SHARED_YT_DLP_SETTINGS,
+                "logger": self._yt_dlp_logger,
+                "format": "best",
+                "merge_output_format": "mp4",
+                "overwrites": True,
+                "outtmpl": os.path.join(
+                    self._config["output_folder"],
+                    "[%(uploader)s] %(title)s.%(ext)s",
+                ),
+                "postprocessor_args": {
+                    "ffmpeg": ["-loglevel", "warning", "-stats", "-stats_period", "60"]
+                },
+                "external_downloader_args": {
+                    "ffmpeg": ["-loglevel", "warning", "-stats", "-stats_period", "60"]
+                },
+                # pip install "curl-cffi>=0.10,<0.15"
+                "impersonate": ImpersonateTarget("chrome", "131"),
+            }
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                ydl.download([url])
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, sync)


### PR DESCRIPTION
## Summary
- Adds `rumble.com` to supported URLs in the Go backend
- Adds a dedicated `RumbleDownloader` class that uses yt-dlp with Chrome
  impersonation (`curl-cffi`) to bypass Cloudflare bot detection on Rumble
- Wires `RumbleDownloader` into the downloader module and service map
- Fixes the fragment part file regex in the video reader to also match
  Rumble's `*.mp4.part-FragNNN.part` naming, skipping them correctly
- Guards `multi_channel_poller` against a missing `channels` key in config
- Disables the JoshStrifeHayes Twitch channel in config

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)