### PR TITLE
Add multi-quality video recode support (#5)

### DIFF
--- a/backend/480p_video_recoder.go
+++ b/backend/480p_video_recoder.go
@@ -32,7 +32,6 @@ func (r *Video480pRecoder) Recode(inputPath, outputPath string) error {
 
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		_ = os.Remove(tmpPath)
 		return err
 	}
 

--- a/backend/480p_video_recoder.go
+++ b/backend/480p_video_recoder.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	ffmpeg "github.com/u2takey/ffmpeg-go"
+)
+
+type Video480pRecoder struct{}
+
+func NewVideo480pRecoder() *Video480pRecoder {
+	return &Video480pRecoder{}
+}
+
+func (r *Video480pRecoder) Recode(inputPath, outputPath string) error {
+	tmpPath := strings.TrimSuffix(outputPath, ".mp4") + ".temp.mp4"
+
+	cmd := ffmpeg.Input(inputPath).
+		Output(tmpPath, ffmpeg.KwArgs{
+			"c:v":       "libx264",
+			"profile:v": "high",
+			"level":     "3.1",
+			"vf":        "scale=-2:min(480\\,ih)",
+			"crf":       "22",
+			"maxrate":   "2500000",
+			"bufsize":   "5000000",
+			"c:a":       "copy",
+			"movflags":  "+faststart",
+		}).
+		Compile()
+
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	return os.Rename(tmpPath, outputPath)
+}

--- a/backend/720p_video_recoder.go
+++ b/backend/720p_video_recoder.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	ffmpeg "github.com/u2takey/ffmpeg-go"
+)
+
+type Video720pRecoder struct{}
+
+func NewVideo720pRecoder() *Video720pRecoder {
+	return &Video720pRecoder{}
+}
+
+func (r *Video720pRecoder) Recode(inputPath, outputPath string) error {
+	tmpPath := strings.TrimSuffix(outputPath, ".mp4") + ".temp.mp4"
+
+	cmd := ffmpeg.Input(inputPath).
+		Output(tmpPath, ffmpeg.KwArgs{
+			"c:v":       "libx264",
+			"profile:v": "high",
+			"level":     "4.0",
+			"vf":        "scale=-2:min(720\\,ih)",
+			"crf":       "20",
+			"maxrate":   "5000000",
+			"bufsize":   "10000000",
+			"c:a":       "copy",
+			"movflags":  "+faststart",
+		}).
+		Compile()
+
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	return os.Rename(tmpPath, outputPath)
+}

--- a/backend/720p_video_recoder.go
+++ b/backend/720p_video_recoder.go
@@ -32,7 +32,6 @@ func (r *Video720pRecoder) Recode(inputPath, outputPath string) error {
 
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		_ = os.Remove(tmpPath)
 		return err
 	}
 

--- a/backend/config.go
+++ b/backend/config.go
@@ -1,6 +1,7 @@
 package main
 
 type Config struct {
-	StreamsDir    string  `yaml:"streams_dir"`
-	SplitDuration float64 `yaml:"split_duration"`
+	StreamsDir      string   `yaml:"streams_dir"`
+	SplitDuration   float64  `yaml:"split_duration"`
+	RecodeQualities []string `yaml:"recode_qualities"`
 }

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,2 +1,5 @@
 streams_dir: "D:/streams"
 split_duration: 10800
+recode_qualities:
+  # - 720p
+  - 480p

--- a/backend/filenames.go
+++ b/backend/filenames.go
@@ -25,3 +25,8 @@ func (f *Filenames) IOSFix(videoPath string) string {
 	base := filepath.Base(videoPath)
 	return strings.TrimSuffix(base, filepath.Ext(base)) + ".ios_fix.txt"
 }
+
+func (f *Filenames) LowerQuality720p(videoPath string) string {
+	base := filepath.Base(videoPath)
+	return strings.TrimSuffix(base, filepath.Ext(base)) + ".720p.mp4"
+}

--- a/backend/filenames.go
+++ b/backend/filenames.go
@@ -30,3 +30,8 @@ func (f *Filenames) LowerQuality720p(videoPath string) string {
 	base := filepath.Base(videoPath)
 	return strings.TrimSuffix(base, filepath.Ext(base)) + ".720p.mp4"
 }
+
+func (f *Filenames) LowerQuality480p(videoPath string) string {
+	base := filepath.Base(videoPath)
+	return strings.TrimSuffix(base, filepath.Ext(base)) + ".480p.mp4"
+}

--- a/backend/filenames.go
+++ b/backend/filenames.go
@@ -26,12 +26,7 @@ func (f *Filenames) IOSFix(videoPath string) string {
 	return strings.TrimSuffix(base, filepath.Ext(base)) + ".ios_fix.txt"
 }
 
-func (f *Filenames) LowerQuality720p(videoPath string) string {
+func (f *Filenames) LowerQuality(videoPath, quality string) string {
 	base := filepath.Base(videoPath)
-	return strings.TrimSuffix(base, filepath.Ext(base)) + ".720p.mp4"
-}
-
-func (f *Filenames) LowerQuality480p(videoPath string) string {
-	base := filepath.Base(videoPath)
-	return strings.TrimSuffix(base, filepath.Ext(base)) + ".480p.mp4"
+	return strings.TrimSuffix(base, filepath.Ext(base)) + "." + quality + ".mp4"
 }

--- a/backend/fix_ios_worker.go
+++ b/backend/fix_ios_worker.go
@@ -1,13 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"time"
-
-	ffmpeg "github.com/u2takey/ffmpeg-go"
 )
 
 type FixIOSWorker struct {
@@ -15,10 +12,11 @@ type FixIOSWorker struct {
 	store             *VideoStore
 	filenames         *Filenames
 	videoIOSValidator *VideoIOSValidator
+	iosVideoRecoder   *IOSVideoRecoder
 }
 
-func NewFixIOSWorker(cfg *Config, store *VideoStore, filenames *Filenames, videoIOSValidator *VideoIOSValidator) *FixIOSWorker {
-	return &FixIOSWorker{cfg: cfg, store: store, filenames: filenames, videoIOSValidator: videoIOSValidator}
+func NewFixIOSWorker(cfg *Config, store *VideoStore, filenames *Filenames, videoIOSValidator *VideoIOSValidator, iosVideoRecoder *IOSVideoRecoder) *FixIOSWorker {
+	return &FixIOSWorker{cfg: cfg, store: store, filenames: filenames, videoIOSValidator: videoIOSValidator, iosVideoRecoder: iosVideoRecoder}
 }
 
 func (fw *FixIOSWorker) Start() {
@@ -33,7 +31,8 @@ func (fw *FixIOSWorker) Start() {
 			}
 			videoPath := filepath.Join(fw.cfg.StreamsDir, v.Filename)
 			fixPath := filepath.Join(fw.cfg.StreamsDir, fw.filenames.IOSFix(v.Filename))
-			// skip if marker exists and video has not been replaced since
+			// don't process if marker exists
+			// process if video is newer than marker
 			if fixInfo, err := os.Stat(fixPath); err == nil {
 				if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(fixInfo.ModTime()) {
 					continue
@@ -51,7 +50,7 @@ func (fw *FixIOSWorker) Start() {
 				continue
 			}
 			log.Println("fixing ios compatibility for", v.Filename)
-			if err := fw.fix(videoPath, validation.Bitrate); err != nil {
+			if err := fw.iosVideoRecoder.Recode(videoPath, validation.Bitrate); err != nil {
 				log.Println("error fixing", v.Filename, ":", err)
 				continue
 			}
@@ -62,37 +61,4 @@ func (fw *FixIOSWorker) Start() {
 		}
 		time.Sleep(1 * time.Minute)
 	}
-}
-
-// fix re-encodes the video with B-frames disabled targeting the original bitrate
-// so iOS can play the file at roughly the same file size. Audio is stream-copied.
-func (fw *FixIOSWorker) fix(videoPath string, bitrate int64) error {
-	ext := filepath.Ext(videoPath)
-	base := videoPath[:len(videoPath)-len(ext)]
-	tmpPath := base + ".temp" + ext
-
-	cmd := ffmpeg.Input(videoPath).
-		Output(tmpPath, ffmpeg.KwArgs{
-			"c:v":       "libx264",
-			"profile:v": "main",
-			"level":     "4.0",
-			"bf":        0,
-			"b:v":       fmt.Sprintf("%d", bitrate),
-			"vf":        "setsar=1:1",
-			"c:a":       "copy",
-			"movflags":  "+faststart",
-		}).
-		Compile()
-
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		_ = os.Remove(tmpPath)
-		return err
-	}
-
-	if err := os.Remove(videoPath); err != nil {
-		_ = os.Remove(tmpPath)
-		return err
-	}
-	return os.Rename(tmpPath, videoPath)
 }

--- a/backend/fix_ios_worker.go
+++ b/backend/fix_ios_worker.go
@@ -21,44 +21,53 @@ func NewFixIOSWorker(cfg *Config, store *VideoStore, filenames *Filenames, video
 
 func (fw *FixIOSWorker) Start() {
 	for {
-		fw.store.Mutex.RLock()
-		current := fw.store.Videos
-		fw.store.Mutex.RUnlock()
+		if !fw.processNext() {
+			time.Sleep(1 * time.Minute)
+		}
+	}
+}
 
-		for _, v := range current {
-			if v.Status != "Ready" {
+// processNext finds the first video that needs iOS fix processing, processes it, and returns true.
+// Returns false if nothing needed processing.
+func (fw *FixIOSWorker) processNext() bool {
+	fw.store.Mutex.RLock()
+	current := fw.store.Videos
+	fw.store.Mutex.RUnlock()
+
+	for _, v := range current {
+		if v.Status != "Ready" {
+			continue
+		}
+		videoPath := filepath.Join(fw.cfg.StreamsDir, v.Filename)
+		fixPath := filepath.Join(fw.cfg.StreamsDir, fw.filenames.IOSFix(v.Filename))
+		// don't process if marker exists
+		// process if video is newer than marker
+		if fixInfo, err := os.Stat(fixPath); err == nil {
+			if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(fixInfo.ModTime()) {
 				continue
 			}
-			videoPath := filepath.Join(fw.cfg.StreamsDir, v.Filename)
-			fixPath := filepath.Join(fw.cfg.StreamsDir, fw.filenames.IOSFix(v.Filename))
-			// don't process if marker exists
-			// process if video is newer than marker
-			if fixInfo, err := os.Stat(fixPath); err == nil {
-				if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(fixInfo.ModTime()) {
-					continue
-				}
-			}
-			validation, err := fw.videoIOSValidator.Validate(videoPath)
-			if err != nil {
-				log.Println("error probing", v.Filename, ":", err)
-				continue
-			}
-			if !validation.NeedsIOSFix {
-				if err := os.WriteFile(fixPath, []byte("ok"), 0644); err != nil {
-					log.Println("error writing ios fix marker for", v.Filename, ":", err)
-				}
-				continue
-			}
-			log.Println("fixing ios compatibility for", v.Filename)
-			if err := fw.iosVideoRecoder.Recode(videoPath, validation.Bitrate); err != nil {
-				log.Println("error fixing", v.Filename, ":", err)
-				continue
-			}
-			if err := os.WriteFile(fixPath, []byte("fixed sar"), 0644); err != nil {
+		}
+		validation, err := fw.videoIOSValidator.Validate(videoPath)
+		if err != nil {
+			log.Println("error probing", v.Filename, ":", err)
+			continue
+		}
+		if !validation.NeedsIOSFix {
+			if err := os.WriteFile(fixPath, []byte("ok"), 0644); err != nil {
 				log.Println("error writing ios fix marker for", v.Filename, ":", err)
 			}
-			log.Println("ios fix done for", v.Filename)
+			return true
 		}
-		time.Sleep(1 * time.Minute)
+		log.Println("fixing ios compatibility for", v.Filename)
+		if err := fw.iosVideoRecoder.Recode(videoPath, validation.Bitrate); err != nil {
+			log.Println("error fixing", v.Filename, ":", err)
+			return true
+		}
+		if err := os.WriteFile(fixPath, []byte("fixed sar"), 0644); err != nil {
+			log.Println("error writing ios fix marker for", v.Filename, ":", err)
+		}
+		log.Println("ios fix done for", v.Filename)
+		return true
 	}
+	return false
 }

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -37,7 +37,14 @@ func (s *GinServer) registerRoutes() {
 		defer s.store.Mutex.RUnlock()
 		response := make([]VideoResponse, len(s.store.Videos))
 		for i, v := range s.store.Videos {
-			response[i] = VideoResponse{ID: v.ID, Name: v.Name, Channel: v.Channel, Date: v.Date, Status: v.Status}
+			response[i] = VideoResponse{
+				ID:       v.ID,
+				Name:     v.Name,
+				Channel:  v.Channel,
+				Date:     v.Date,
+				Status:   v.Status,
+				Versions: v.Versions,
+			}
 		}
 		c.JSON(200, response)
 	})

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -65,13 +65,20 @@ func (s *GinServer) registerRoutes() {
 		id := c.Param("id")
 		s.store.Mutex.RLock()
 		v, ok := s.store.VideosMap[id]
+		vv, versionOk := s.store.VideoVersionsMap[id]
 		s.store.Mutex.RUnlock()
-		if !ok {
+		if !ok && !versionOk {
 			c.Status(404)
 			return
 		}
-		c.Header("Content-Disposition", `attachment; filename="`+v.Filename+`"`)
-		s.fileServer.Serve(c, s.cfg.StreamsDir+"/"+v.Filename, v.Filename)
+		var filename string
+		if versionOk {
+			filename = vv.Filename
+		} else {
+			filename = v.Filename
+		}
+		c.Header("Content-Disposition", `attachment; filename="`+filename+`"`)
+		s.fileServer.Serve(c, s.cfg.StreamsDir+"/"+filename, filename)
 	})
 
 	s.router.GET("/duration/:id", func(c *gin.Context) {

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -28,7 +28,14 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewVideoSplitter),
 		fx.Provide(NewSplitVideosWorker),
 		fx.Provide(NewFixIOSWorker),
-		fx.Provide(NewLowerQualityVideoRecoder),
+		fx.Provide(NewVideo720pRecoder),
+		fx.Provide(NewVideo480pRecoder),
+		fx.Provide(func(r720 *Video720pRecoder, r480 *Video480pRecoder) map[string]LowerQualityVideoRecoder {
+			return map[string]LowerQualityVideoRecoder{
+				"720p": r720,
+				"480p": r480,
+			}
+		}),
 		fx.Provide(NewLowerQualityRecoderWorker),
 		fx.Provide(NewDownloadRequestService),
 		fx.Provide(NewGinServer),

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -27,6 +27,8 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewVideoSplitter),
 		fx.Provide(NewSplitVideosWorker),
 		fx.Provide(NewFixIOSWorker),
+		fx.Provide(NewLowerQualityVideoRecoder),
+		fx.Provide(NewLowerQualityRecoderWorker),
 		fx.Provide(NewDownloadRequestService),
 		fx.Provide(NewGinServer),
 	)
@@ -43,6 +45,7 @@ func NewIOC() *fx.App {
 			durationsWorker *DurationsWorker,
 			splitVideosWorker *SplitVideosWorker,
 			fixIOSWorker *FixIOSWorker,
+			lowerQualityRecoderWorker *LowerQualityRecoderWorker,
 			cleanupWorker *CleanupWorker) {
 			lc.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {
@@ -53,6 +56,7 @@ func NewIOC() *fx.App {
 						go durationsWorker.Start()
 						go splitVideosWorker.Start()
 						go fixIOSWorker.Start()
+						go lowerQualityRecoderWorker.Start()
 						go cleanupWorker.Start()
 					}()
 					return nil

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -12,6 +12,7 @@ func CoreProviders() fx.Option {
 	return fx.Options(
 		fx.Provide(func() *Config { cfg := loadConfig(); return &cfg }),
 		fx.Provide(func(cfg *Config) StreamsFS { return StreamsFS(os.DirFS(cfg.StreamsDir)) }),
+		fx.Provide(NewVideoID),
 		fx.Provide(NewFilenames),
 		fx.Provide(NewVideoDuration),
 		fx.Provide(NewThumbnailSaver),

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -23,6 +23,7 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewVideoReader),
 		fx.Provide(NewPollVideosWorker),
 		fx.Provide(NewVideoIOSValidator),
+		fx.Provide(NewIOSVideoRecoder),
 		fx.Provide(NewVideoSplitter),
 		fx.Provide(NewSplitVideosWorker),
 		fx.Provide(NewFixIOSWorker),

--- a/backend/ios_video_recoder.go
+++ b/backend/ios_video_recoder.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	ffmpeg "github.com/u2takey/ffmpeg-go"
+)
+
+// IOSVideoRecoder re-encodes a video with B-frames disabled targeting the original
+// bitrate so iOS can play the file at roughly the same file size. Audio is
+// stream-copied.
+type IOSVideoRecoder struct{}
+
+func NewIOSVideoRecoder() *IOSVideoRecoder {
+	return &IOSVideoRecoder{}
+}
+
+func (r *IOSVideoRecoder) Recode(videoPath string, bitrate int64) error {
+	ext := filepath.Ext(videoPath)
+	base := videoPath[:len(videoPath)-len(ext)]
+	tmpPath := base + ".temp" + ext
+
+	cmd := ffmpeg.Input(videoPath).
+		Output(tmpPath, ffmpeg.KwArgs{
+			"c:v":       "libx264",
+			"profile:v": "main",
+			"level":     "4.0",
+			"bf":        0,
+			"b:v":       fmt.Sprintf("%d", bitrate),
+			"vf":        "setsar=1:1",
+			"c:a":       "copy",
+			"movflags":  "+faststart",
+		}).
+		Compile()
+
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	if err := os.Remove(videoPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, videoPath)
+}

--- a/backend/ios_video_recoder.go
+++ b/backend/ios_video_recoder.go
@@ -37,12 +37,10 @@ func (r *IOSVideoRecoder) Recode(videoPath string, bitrate int64) error {
 
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		_ = os.Remove(tmpPath)
 		return err
 	}
 
 	if err := os.Remove(videoPath); err != nil {
-		_ = os.Remove(tmpPath)
 		return err
 	}
 	return os.Rename(tmpPath, videoPath)

--- a/backend/lower_quality_recoder_worker.go
+++ b/backend/lower_quality_recoder_worker.go
@@ -8,15 +8,14 @@ import (
 )
 
 type LowerQualityRecoderWorker struct {
-	cfg               *Config
-	store             *VideoStore
-	filenames         *Filenames
-	videoIOSValidator *VideoIOSValidator
-	recoder           *LowerQualityVideoRecoder
+	cfg       *Config
+	store     *VideoStore
+	filenames *Filenames
+	recoder   *LowerQualityVideoRecoder
 }
 
-func NewLowerQualityRecoderWorker(cfg *Config, store *VideoStore, filenames *Filenames, videoIOSValidator *VideoIOSValidator, recoder *LowerQualityVideoRecoder) *LowerQualityRecoderWorker {
-	return &LowerQualityRecoderWorker{cfg: cfg, store: store, filenames: filenames, videoIOSValidator: videoIOSValidator, recoder: recoder}
+func NewLowerQualityRecoderWorker(cfg *Config, store *VideoStore, filenames *Filenames, recoder *LowerQualityVideoRecoder) *LowerQualityRecoderWorker {
+	return &LowerQualityRecoderWorker{cfg: cfg, store: store, filenames: filenames, recoder: recoder}
 }
 
 func (w *LowerQualityRecoderWorker) Start() {
@@ -43,13 +42,8 @@ func (w *LowerQualityRecoderWorker) Start() {
 					continue
 				}
 			}
-			validation, err := w.videoIOSValidator.Validate(videoPath)
-			if err != nil {
-				log.Println("error probing", v.Filename, ":", err)
-				continue
-			}
 			log.Println("recoding to 720p:", v.Filename)
-			if err := w.recoder.Recode(videoPath, outputPath, validation.Bitrate); err != nil {
+			if err := w.recoder.Recode(videoPath, outputPath); err != nil {
 				log.Println("error recoding to 720p", v.Filename, ":", err)
 				continue
 			}

--- a/backend/lower_quality_recoder_worker.go
+++ b/backend/lower_quality_recoder_worker.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type LowerQualityRecoderWorker struct {
+	cfg               *Config
+	store             *VideoStore
+	filenames         *Filenames
+	videoIOSValidator *VideoIOSValidator
+	recoder           *LowerQualityVideoRecoder
+}
+
+func NewLowerQualityRecoderWorker(cfg *Config, store *VideoStore, filenames *Filenames, videoIOSValidator *VideoIOSValidator, recoder *LowerQualityVideoRecoder) *LowerQualityRecoderWorker {
+	return &LowerQualityRecoderWorker{cfg: cfg, store: store, filenames: filenames, videoIOSValidator: videoIOSValidator, recoder: recoder}
+}
+
+func (w *LowerQualityRecoderWorker) Start() {
+	for {
+		w.store.Mutex.RLock()
+		current := w.store.Videos
+		w.store.Mutex.RUnlock()
+
+		for _, v := range current {
+			if v.Status != "Ready" {
+				continue
+			}
+			videoPath := filepath.Join(w.cfg.StreamsDir, v.Filename)
+			fixPath := filepath.Join(w.cfg.StreamsDir, w.filenames.IOSFix(v.Filename))
+			// don't process if iOS fix marker is missing
+			if _, err := os.Stat(fixPath); err != nil {
+				continue
+			}
+			outputPath := filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality720p(v.Filename))
+			// don't recode if 720p already exists
+			// recode if original is newer than 720p
+			if outInfo, err := os.Stat(outputPath); err == nil {
+				if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(outInfo.ModTime()) {
+					continue
+				}
+			}
+			validation, err := w.videoIOSValidator.Validate(videoPath)
+			if err != nil {
+				log.Println("error probing", v.Filename, ":", err)
+				continue
+			}
+			log.Println("recoding to 720p:", v.Filename)
+			if err := w.recoder.Recode(videoPath, outputPath, validation.Bitrate); err != nil {
+				log.Println("error recoding to 720p", v.Filename, ":", err)
+				continue
+			}
+			log.Println("720p recode done for", v.Filename)
+		}
+		time.Sleep(1 * time.Minute)
+	}
+}

--- a/backend/lower_quality_recoder_worker.go
+++ b/backend/lower_quality_recoder_worker.go
@@ -20,42 +20,51 @@ func NewLowerQualityRecoderWorker(cfg *Config, store *VideoStore, filenames *Fil
 
 func (w *LowerQualityRecoderWorker) Start() {
 	for {
-		w.store.Mutex.RLock()
-		current := w.store.Videos
-		w.store.Mutex.RUnlock()
+		if !w.processNext() {
+			time.Sleep(1 * time.Minute)
+		}
+	}
+}
 
-		for _, v := range current {
-			if v.Status != "Ready" {
-				continue
-			}
-			videoPath := filepath.Join(w.cfg.StreamsDir, v.Filename)
-			fixPath := filepath.Join(w.cfg.StreamsDir, w.filenames.IOSFix(v.Filename))
-			// don't process if iOS fix marker is missing
-			if _, err := os.Stat(fixPath); err != nil {
-				continue
-			}
-			qualities := []struct {
-				key        string
-				outputPath string
-			}{
-				{"720p", filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality720p(v.Filename))},
-				{"480p", filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality480p(v.Filename))},
-			}
-			for _, q := range qualities {
-				// run if original is newer than output, skip if up-to-date
-				if outInfo, err := os.Stat(q.outputPath); err == nil {
-					if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(outInfo.ModTime()) {
-						continue
-					}
-				}
-				log.Println("recoding to "+q.key+":", v.Filename)
-				if err := w.recoders[q.key].Recode(videoPath, q.outputPath); err != nil {
-					log.Println("error recoding to "+q.key, v.Filename, ":", err)
+// processNext finds the first video+quality that needs recoding, processes it, and returns true.
+// Returns false if nothing needed processing.
+func (w *LowerQualityRecoderWorker) processNext() bool {
+	w.store.Mutex.RLock()
+	current := w.store.Videos
+	w.store.Mutex.RUnlock()
+
+	for _, v := range current {
+		if v.Status != "Ready" {
+			continue
+		}
+		videoPath := filepath.Join(w.cfg.StreamsDir, v.Filename)
+		fixPath := filepath.Join(w.cfg.StreamsDir, w.filenames.IOSFix(v.Filename))
+		// don't process if iOS fix marker is missing
+		if _, err := os.Stat(fixPath); err != nil {
+			continue
+		}
+		qualities := []struct {
+			key        string
+			outputPath string
+		}{
+			{"720p", filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality720p(v.Filename))},
+			{"480p", filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality480p(v.Filename))},
+		}
+		for _, q := range qualities {
+			// run if original is newer than output, skip if up-to-date
+			if outInfo, err := os.Stat(q.outputPath); err == nil {
+				if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(outInfo.ModTime()) {
 					continue
 				}
+			}
+			log.Println("recoding to "+q.key+":", v.Filename)
+			if err := w.recoders[q.key].Recode(videoPath, q.outputPath); err != nil {
+				log.Println("error recoding to "+q.key, v.Filename, ":", err)
+			} else {
 				log.Println(q.key+" recode done for", v.Filename)
 			}
+			return true
 		}
-		time.Sleep(1 * time.Minute)
 	}
+	return false
 }

--- a/backend/lower_quality_recoder_worker.go
+++ b/backend/lower_quality_recoder_worker.go
@@ -35,8 +35,8 @@ func (w *LowerQualityRecoderWorker) Start() {
 				continue
 			}
 			outputPath := filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality720p(v.Filename))
-			// don't recode if 720p already exists
-			// recode if original is newer than 720p
+			// run if original is newer than 720p
+			// don't run if 720p exists and is up-to-date
 			if outInfo, err := os.Stat(outputPath); err == nil {
 				if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(outInfo.ModTime()) {
 					continue

--- a/backend/lower_quality_recoder_worker.go
+++ b/backend/lower_quality_recoder_worker.go
@@ -34,20 +34,27 @@ func (w *LowerQualityRecoderWorker) Start() {
 			if _, err := os.Stat(fixPath); err != nil {
 				continue
 			}
-			outputPath := filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality720p(v.Filename))
-			// run if original is newer than 720p
-			// don't run if 720p exists and is up-to-date
-			if outInfo, err := os.Stat(outputPath); err == nil {
-				if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(outInfo.ModTime()) {
+			qualities := []struct {
+				key        string
+				outputPath string
+			}{
+				{"720p", filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality720p(v.Filename))},
+				{"480p", filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality480p(v.Filename))},
+			}
+			for _, q := range qualities {
+				// run if original is newer than output, skip if up-to-date
+				if outInfo, err := os.Stat(q.outputPath); err == nil {
+					if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(outInfo.ModTime()) {
+						continue
+					}
+				}
+				log.Println("recoding to "+q.key+":", v.Filename)
+				if err := w.recoders[q.key].Recode(videoPath, q.outputPath); err != nil {
+					log.Println("error recoding to "+q.key, v.Filename, ":", err)
 					continue
 				}
+				log.Println(q.key+" recode done for", v.Filename)
 			}
-			log.Println("recoding to 720p:", v.Filename)
-			if err := w.recoders["720p"].Recode(videoPath, outputPath); err != nil {
-				log.Println("error recoding to 720p", v.Filename, ":", err)
-				continue
-			}
-			log.Println("720p recode done for", v.Filename)
 		}
 		time.Sleep(1 * time.Minute)
 	}

--- a/backend/lower_quality_recoder_worker.go
+++ b/backend/lower_quality_recoder_worker.go
@@ -8,14 +8,14 @@ import (
 )
 
 type LowerQualityRecoderWorker struct {
-	cfg       *Config
-	store     *VideoStore
+	cfg      *Config
+	store    *VideoStore
 	filenames *Filenames
-	recoder   *LowerQualityVideoRecoder
+	recoders map[string]LowerQualityVideoRecoder
 }
 
-func NewLowerQualityRecoderWorker(cfg *Config, store *VideoStore, filenames *Filenames, recoder *LowerQualityVideoRecoder) *LowerQualityRecoderWorker {
-	return &LowerQualityRecoderWorker{cfg: cfg, store: store, filenames: filenames, recoder: recoder}
+func NewLowerQualityRecoderWorker(cfg *Config, store *VideoStore, filenames *Filenames, recoders map[string]LowerQualityVideoRecoder) *LowerQualityRecoderWorker {
+	return &LowerQualityRecoderWorker{cfg: cfg, store: store, filenames: filenames, recoders: recoders}
 }
 
 func (w *LowerQualityRecoderWorker) Start() {
@@ -43,7 +43,7 @@ func (w *LowerQualityRecoderWorker) Start() {
 				}
 			}
 			log.Println("recoding to 720p:", v.Filename)
-			if err := w.recoder.Recode(videoPath, outputPath); err != nil {
+			if err := w.recoders["720p"].Recode(videoPath, outputPath); err != nil {
 				log.Println("error recoding to 720p", v.Filename, ":", err)
 				continue
 			}

--- a/backend/lower_quality_recoder_worker.go
+++ b/backend/lower_quality_recoder_worker.go
@@ -43,25 +43,19 @@ func (w *LowerQualityRecoderWorker) processNext() bool {
 		if _, err := os.Stat(fixPath); err != nil {
 			continue
 		}
-		qualities := []struct {
-			key        string
-			outputPath string
-		}{
-			{"720p", filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality720p(v.Filename))},
-			{"480p", filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality480p(v.Filename))},
-		}
-		for _, q := range qualities {
+		for _, quality := range w.cfg.RecodeQualities {
+			outputPath := filepath.Join(w.cfg.StreamsDir, w.filenames.LowerQuality(v.Filename, quality))
 			// run if original is newer than output, skip if up-to-date
-			if outInfo, err := os.Stat(q.outputPath); err == nil {
+			if outInfo, err := os.Stat(outputPath); err == nil {
 				if vInfo, err := os.Stat(videoPath); err != nil || !vInfo.ModTime().After(outInfo.ModTime()) {
 					continue
 				}
 			}
-			log.Println("recoding to "+q.key+":", v.Filename)
-			if err := w.recoders[q.key].Recode(videoPath, q.outputPath); err != nil {
-				log.Println("error recoding to "+q.key, v.Filename, ":", err)
+			log.Println("recoding to "+quality+":", v.Filename)
+			if err := w.recoders[quality].Recode(videoPath, outputPath); err != nil {
+				log.Println("error recoding to "+quality, v.Filename, ":", err)
 			} else {
-				log.Println(q.key+" recode done for", v.Filename)
+				log.Println(quality+" recode done for", v.Filename)
 			}
 			return true
 		}

--- a/backend/lower_quality_video_recoder.go
+++ b/backend/lower_quality_video_recoder.go
@@ -1,40 +1,5 @@
 package main
 
-import (
-	"os"
-	"strings"
-
-	ffmpeg "github.com/u2takey/ffmpeg-go"
-)
-
-type LowerQualityVideoRecoder struct{}
-
-func NewLowerQualityVideoRecoder() *LowerQualityVideoRecoder {
-	return &LowerQualityVideoRecoder{}
-}
-
-func (r *LowerQualityVideoRecoder) Recode(inputPath, outputPath string) error {
-	tmpPath := strings.TrimSuffix(outputPath, ".mp4") + ".temp.mp4"
-
-	cmd := ffmpeg.Input(inputPath).
-		Output(tmpPath, ffmpeg.KwArgs{
-			"c:v":       "libx264",
-			"profile:v": "high",
-			"level":     "4.0",
-			"vf":        "scale=-2:min(720\\,ih)",
-			"crf":       "20",
-			"maxrate":   "5000000",
-			"bufsize":   "10000000",
-			"c:a":       "copy",
-			"movflags":  "+faststart",
-		}).
-		Compile()
-
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		_ = os.Remove(tmpPath)
-		return err
-	}
-
-	return os.Rename(tmpPath, outputPath)
+type LowerQualityVideoRecoder interface {
+	Recode(inputPath, outputPath string) error
 }

--- a/backend/lower_quality_video_recoder.go
+++ b/backend/lower_quality_video_recoder.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -14,16 +13,18 @@ func NewLowerQualityVideoRecoder() *LowerQualityVideoRecoder {
 	return &LowerQualityVideoRecoder{}
 }
 
-func (r *LowerQualityVideoRecoder) Recode(inputPath, outputPath string, bitrate int64) error {
+func (r *LowerQualityVideoRecoder) Recode(inputPath, outputPath string) error {
 	tmpPath := strings.TrimSuffix(outputPath, ".mp4") + ".720p.temp.mp4"
 
 	cmd := ffmpeg.Input(inputPath).
 		Output(tmpPath, ffmpeg.KwArgs{
 			"c:v":       "libx264",
-			"profile:v": "main",
+			"profile:v": "high",
 			"level":     "4.0",
-			"vf":        "scale=-2:720",
-			"b:v":       fmt.Sprintf("%d", bitrate),
+			"vf":        "scale=-2:min(720\\,ih)",
+			"crf":       "20",
+			"maxrate":   "5000000",
+			"bufsize":   "10000000",
 			"c:a":       "copy",
 			"movflags":  "+faststart",
 		}).

--- a/backend/lower_quality_video_recoder.go
+++ b/backend/lower_quality_video_recoder.go
@@ -14,7 +14,7 @@ func NewLowerQualityVideoRecoder() *LowerQualityVideoRecoder {
 }
 
 func (r *LowerQualityVideoRecoder) Recode(inputPath, outputPath string) error {
-	tmpPath := strings.TrimSuffix(outputPath, ".mp4") + ".720p.temp.mp4"
+	tmpPath := strings.TrimSuffix(outputPath, ".mp4") + ".temp.mp4"
 
 	cmd := ffmpeg.Input(inputPath).
 		Output(tmpPath, ffmpeg.KwArgs{
@@ -36,9 +36,5 @@ func (r *LowerQualityVideoRecoder) Recode(inputPath, outputPath string) error {
 		return err
 	}
 
-	if err := os.Remove(outputPath); err != nil && !os.IsNotExist(err) {
-		_ = os.Remove(tmpPath)
-		return err
-	}
 	return os.Rename(tmpPath, outputPath)
 }

--- a/backend/lower_quality_video_recoder.go
+++ b/backend/lower_quality_video_recoder.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	ffmpeg "github.com/u2takey/ffmpeg-go"
+)
+
+type LowerQualityVideoRecoder struct{}
+
+func NewLowerQualityVideoRecoder() *LowerQualityVideoRecoder {
+	return &LowerQualityVideoRecoder{}
+}
+
+func (r *LowerQualityVideoRecoder) Recode(inputPath, outputPath string, bitrate int64) error {
+	tmpPath := strings.TrimSuffix(outputPath, ".mp4") + ".720p.temp.mp4"
+
+	cmd := ffmpeg.Input(inputPath).
+		Output(tmpPath, ffmpeg.KwArgs{
+			"c:v":       "libx264",
+			"profile:v": "main",
+			"level":     "4.0",
+			"vf":        "scale=-2:720",
+			"b:v":       fmt.Sprintf("%d", bitrate),
+			"c:a":       "copy",
+			"movflags":  "+faststart",
+		}).
+		Compile()
+
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	if err := os.Remove(outputPath); err != nil && !os.IsNotExist(err) {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, outputPath)
+}

--- a/backend/poll_videos_worker.go
+++ b/backend/poll_videos_worker.go
@@ -21,12 +21,17 @@ func (pw *PollVideosWorker) Start() {
 			log.Println("error fetching videos:", err)
 		} else {
 			m := make(map[string]Video, len(fetched))
+			vm := make(map[string]VideoVersion)
 			for _, v := range fetched {
 				m[v.ID] = v
+				for _, vv := range v.Versions {
+					vm[vv.ID] = vv
+				}
 			}
 			pw.store.Mutex.Lock()
 			pw.store.Videos = fetched
 			pw.store.VideosMap = m
+			pw.store.VideoVersionsMap = vm
 			pw.store.Mutex.Unlock()
 			log.Println("loaded", len(fetched), "videos")
 		}

--- a/backend/split_videos_worker.go
+++ b/backend/split_videos_worker.go
@@ -19,42 +19,52 @@ func NewSplitVideosWorker(cfg *Config, store *VideoStore, videoDuration *VideoDu
 	return &SplitVideosWorker{cfg: cfg, store: store, videoDuration: videoDuration, videoSplitter: videoSplitter, videoIOSValidator: videoIOSValidator}
 }
 
+var splitPartRe = regexp.MustCompile(` part\d{2}\.mp4$`)
+
 func (sw *SplitVideosWorker) Start() {
 	if sw.cfg.SplitDuration == 0 {
 		log.Fatal("split_duration is not set in config")
 	}
 	for {
-		sw.store.Mutex.RLock()
-		current := sw.store.Videos
-		sw.store.Mutex.RUnlock()
-
-		splitPartRe := regexp.MustCompile(` part\d{2}\.mp4$`)
-		for _, v := range current {
-			if v.Status != "Ready" || splitPartRe.MatchString(v.Filename) {
-				continue
-			}
-			videoPath := filepath.Join(sw.cfg.StreamsDir, v.Filename)
-			dur, err := sw.videoDuration.Get(videoPath)
-			if err != nil {
-				log.Println("error probing", v.Filename, ":", err)
-				continue
-			}
-			if dur <= sw.cfg.SplitDuration {
-				continue
-			}
-			validation, err := sw.videoIOSValidator.Validate(videoPath)
-			if err != nil {
-				log.Println("error validating ios compatibility for", v.Filename, ":", err)
-				continue
-			}
-			if validation.NeedsIOSFix {
-				log.Println("skipping split for", v.Filename, "— ios fix pending")
-				continue
-			}
-			if err := sw.videoSplitter.Split(videoPath, sw.cfg.SplitDuration); err != nil {
-				log.Println("error splitting", v.Filename, ":", err)
-			}
+		if !sw.processNext() {
+			time.Sleep(1 * time.Minute)
 		}
-		time.Sleep(1 * time.Minute)
 	}
+}
+
+// processNext finds the first video that needs splitting, processes it, and returns true.
+// Returns false if nothing needed processing.
+func (sw *SplitVideosWorker) processNext() bool {
+	sw.store.Mutex.RLock()
+	current := sw.store.Videos
+	sw.store.Mutex.RUnlock()
+
+	for _, v := range current {
+		if v.Status != "Ready" || splitPartRe.MatchString(v.Filename) {
+			continue
+		}
+		videoPath := filepath.Join(sw.cfg.StreamsDir, v.Filename)
+		dur, err := sw.videoDuration.Get(videoPath)
+		if err != nil {
+			log.Println("error probing", v.Filename, ":", err)
+			continue
+		}
+		if dur <= sw.cfg.SplitDuration {
+			continue
+		}
+		validation, err := sw.videoIOSValidator.Validate(videoPath)
+		if err != nil {
+			log.Println("error validating ios compatibility for", v.Filename, ":", err)
+			continue
+		}
+		if validation.NeedsIOSFix {
+			log.Println("skipping split for", v.Filename, "— ios fix pending")
+			continue
+		}
+		if err := sw.videoSplitter.Split(videoPath, sw.cfg.SplitDuration); err != nil {
+			log.Println("error splitting", v.Filename, ":", err)
+		}
+		return true
+	}
+	return false
 }

--- a/backend/split_videos_worker.go
+++ b/backend/split_videos_worker.go
@@ -2,21 +2,22 @@ package main
 
 import (
 	"log"
+	"os"
 	"path/filepath"
 	"regexp"
 	"time"
 )
 
 type SplitVideosWorker struct {
-	cfg              *Config
-	store            *VideoStore
-	videoDuration    *VideoDuration
-	videoSplitter    *VideoSplitter
-	videoIOSValidator *VideoIOSValidator
+	cfg           *Config
+	store         *VideoStore
+	filenames     *Filenames
+	videoDuration *VideoDuration
+	videoSplitter *VideoSplitter
 }
 
-func NewSplitVideosWorker(cfg *Config, store *VideoStore, videoDuration *VideoDuration, videoSplitter *VideoSplitter, videoIOSValidator *VideoIOSValidator) *SplitVideosWorker {
-	return &SplitVideosWorker{cfg: cfg, store: store, videoDuration: videoDuration, videoSplitter: videoSplitter, videoIOSValidator: videoIOSValidator}
+func NewSplitVideosWorker(cfg *Config, store *VideoStore, filenames *Filenames, videoDuration *VideoDuration, videoSplitter *VideoSplitter) *SplitVideosWorker {
+	return &SplitVideosWorker{cfg: cfg, store: store, filenames: filenames, videoDuration: videoDuration, videoSplitter: videoSplitter}
 }
 
 var splitPartRe = regexp.MustCompile(` part\d{2}\.mp4$`)
@@ -52,13 +53,9 @@ func (sw *SplitVideosWorker) processNext() bool {
 		if dur <= sw.cfg.SplitDuration {
 			continue
 		}
-		validation, err := sw.videoIOSValidator.Validate(videoPath)
-		if err != nil {
-			log.Println("error validating ios compatibility for", v.Filename, ":", err)
-			continue
-		}
-		if validation.NeedsIOSFix {
-			log.Println("skipping split for", v.Filename, "— ios fix pending")
+		fixPath := filepath.Join(sw.cfg.StreamsDir, sw.filenames.IOSFix(v.Filename))
+		if _, err := os.Stat(fixPath); err != nil {
+			log.Println("skipping split for", v.Filename, "— ios fix not done yet")
 			continue
 		}
 		if err := sw.videoSplitter.Split(videoPath, sw.cfg.SplitDuration); err != nil {

--- a/backend/video.go
+++ b/backend/video.go
@@ -9,4 +9,5 @@ type Video struct {
 	Channel  string    `json:"channel"`
 	Date     time.Time `json:"date"`
 	Status   string    `json:"status"`
+	Versions []string  `json:"versions"`
 }

--- a/backend/video.go
+++ b/backend/video.go
@@ -9,5 +9,5 @@ type Video struct {
 	Channel  string    `json:"channel"`
 	Date     time.Time `json:"date"`
 	Status   string    `json:"status"`
-	Versions []string  `json:"versions"`
+	Versions []VideoVersion `json:"versions"`
 }

--- a/backend/video_id.go
+++ b/backend/video_id.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/google/uuid"
+
+type VideoID struct{}
+
+func NewVideoID() *VideoID {
+	return &VideoID{}
+}
+
+func (v *VideoID) FromFilename(filename string) string {
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(filename)).String()
+}

--- a/backend/video_reader.go
+++ b/backend/video_reader.go
@@ -48,6 +48,7 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 				ID:       vr.videoID.FromFilename(versionFilename),
 				Name:     versionName,
 				Filename: versionFilename,
+				Quality:  m[1],
 			})
 		}
 	}

--- a/backend/video_reader.go
+++ b/backend/video_reader.go
@@ -6,17 +6,16 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 type VideoReader struct {
-	cfg *Config
-	fs  StreamsFS
+	cfg     *Config
+	fs      StreamsFS
+	videoID *VideoID
 }
 
-func NewVideoReader(cfg *Config, fsys StreamsFS) *VideoReader {
-	return &VideoReader{cfg: cfg, fs: fsys}
+func NewVideoReader(cfg *Config, fsys StreamsFS, videoID *VideoID) *VideoReader {
+	return &VideoReader{cfg: cfg, fs: fsys, videoID: videoID}
 }
 
 func (vr *VideoReader) GetVideos() ([]Video, error) {
@@ -34,11 +33,21 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 	formatSegmentRe := regexp.MustCompile(`\.f\d{3}$`)
 
 	// pre-scan: build map of base filename -> available lower quality versions (e.g. "720p")
-	lowerQualityVersions := map[string][]string{}
+	lowerQualityVersions := map[string][]VideoVersion{}
 	for _, entry := range entries {
 		if m := lowerQualityRe.FindStringSubmatch(entry.Name()); m != nil {
 			base := strings.TrimSuffix(entry.Name(), "."+m[1]+".mp4") + ".mp4"
-			lowerQualityVersions[base] = append(lowerQualityVersions[base], m[1])
+			versionFilename := entry.Name()
+			versionName := strings.TrimSuffix(versionFilename, "."+m[1]+".mp4")
+			versionName = formatSegmentRe.ReplaceAllString(versionName, "")
+			if mc := channelRe.FindStringSubmatch(versionName); mc != nil {
+				versionName = versionName[len(mc[0]):]
+			}
+			lowerQualityVersions[base] = append(lowerQualityVersions[base], VideoVersion{
+				ID:       vr.videoID.FromFilename(versionFilename),
+				Name:     versionName,
+				Filename: versionFilename,
+			})
 		}
 	}
 
@@ -140,7 +149,7 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 			name = name[len(m[0]):]
 		}
 		v := Video{
-			ID:       uuid.NewSHA1(uuid.NameSpaceURL, []byte(entry.Name())).String(),
+			ID:       vr.videoID.FromFilename(entry.Name()),
 			Filename: entry.Name(),
 			Name:     name,
 			Channel:  channel,

--- a/backend/video_reader.go
+++ b/backend/video_reader.go
@@ -30,7 +30,6 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 	downloadingPartRe := regexp.MustCompile(`\.f\d{3}\.[^.]+\.part$`)
 	fragmentPartRe := regexp.MustCompile(`\.mp4\.part-(?:Frag)?\d+\.part$`)
 	lowerQualityRe := regexp.MustCompile(`\.(720p|480p)\.mp4$`)
-	lowerQualityTempRe := regexp.MustCompile(`\.(720p|480p)\.temp\.mp4$`)
 	channelRe := regexp.MustCompile(`^\[([^\]]+)\] ?`)
 	formatSegmentRe := regexp.MustCompile(`\.f\d{3}$`)
 
@@ -40,15 +39,6 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 		if m := lowerQualityRe.FindStringSubmatch(entry.Name()); m != nil {
 			base := strings.TrimSuffix(entry.Name(), "."+m[1]+".mp4") + ".mp4"
 			lowerQualityVersions[base] = append(lowerQualityVersions[base], m[1])
-		}
-	}
-
-	// pre-scan: find videos being actively recoded to a lower quality
-	recodingInProgress := map[string]bool{}
-	for _, entry := range entries {
-		if m := lowerQualityTempRe.FindStringSubmatch(entry.Name()); m != nil {
-			base := strings.TrimSuffix(entry.Name(), "."+m[1]+".temp.mp4") + ".mp4"
-			recodingInProgress[base] = true
 		}
 	}
 
@@ -85,7 +75,7 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 			continue
 		}
 		// skip lower quality temp files, e.g. "video.720p.temp.mp4" — recode in progress
-		if lowerQualityTempRe.MatchString(entry.Name()) {
+		if strings.Contains(entry.Name(), ".720p.temp.mp4") || strings.Contains(entry.Name(), ".480p.temp.mp4") {
 			continue
 		}
 		status := "Ready"
@@ -116,10 +106,6 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 			// if a temp file exists alongside the final mp4, mark as Processing
 			base, _ := strings.CutSuffix(entry.Name(), ".mp4")
 			if _, err := fs.Stat(vr.fs, base+".temp.mp4"); err == nil {
-				status = "Processing"
-			}
-			// if a lower quality recode is in progress, mark as Processing
-			if recodingInProgress[entry.Name()] {
 				status = "Processing"
 			}
 		}

--- a/backend/video_reader.go
+++ b/backend/video_reader.go
@@ -43,6 +43,7 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 			if mc := channelRe.FindStringSubmatch(versionName); mc != nil {
 				versionName = versionName[len(mc[0]):]
 			}
+			versionName = versionName + " " + m[1]
 			lowerQualityVersions[base] = append(lowerQualityVersions[base], VideoVersion{
 				ID:       vr.videoID.FromFilename(versionFilename),
 				Name:     versionName,

--- a/backend/video_reader.go
+++ b/backend/video_reader.go
@@ -29,8 +29,18 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 	formatRe := regexp.MustCompile(`f\d{3}\.mp4$`)
 	downloadingPartRe := regexp.MustCompile(`\.f\d{3}\.[^.]+\.part$`)
 	fragmentPartRe := regexp.MustCompile(`\.mp4\.part-(?:Frag)?\d+\.part$`)
+	lowerQualityRe := regexp.MustCompile(`\.(720p|480p)\.mp4$`)
 	channelRe := regexp.MustCompile(`^\[([^\]]+)\] ?`)
 	formatSegmentRe := regexp.MustCompile(`\.f\d{3}$`)
+
+	// pre-scan: build map of base filename -> available lower quality versions (e.g. "720p")
+	lowerQualityVersions := map[string][]string{}
+	for _, entry := range entries {
+		if m := lowerQualityRe.FindStringSubmatch(entry.Name()); m != nil {
+			base := strings.TrimSuffix(entry.Name(), "."+m[1]+".mp4") + ".mp4"
+			lowerQualityVersions[base] = append(lowerQualityVersions[base], m[1])
+		}
+	}
 
 	// pre-scan: for each base name, find the largest part file
 	largestDownloadingPart := map[string]string{} // base -> filename of largest .part file
@@ -58,6 +68,10 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 		// skip non-mp4/part files, e.g. "video.jpg", "video.mp4.duration.txt"
 		ext := strings.ToLower(filepath.Ext(entry.Name()))
 		if ext != ".mp4" && ext != ".part" {
+			continue
+		}
+		// skip lower quality versions, e.g. "video.720p.mp4" — exposed via Versions on the original
+		if lowerQualityRe.MatchString(entry.Name()) {
 			continue
 		}
 		status := "Ready"
@@ -128,6 +142,7 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 			Channel:  channel,
 			Date:     info.ModTime(),
 			Status:   status,
+			Versions: lowerQualityVersions[entry.Name()],
 		}
 		// log.Printf("video: id=%s name=%s date=%s", v.ID, v.Name, v.Date.Format("2006-01-02 15:04:05"))
 		videos = append(videos, v)

--- a/backend/video_reader.go
+++ b/backend/video_reader.go
@@ -30,6 +30,7 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 	downloadingPartRe := regexp.MustCompile(`\.f\d{3}\.[^.]+\.part$`)
 	fragmentPartRe := regexp.MustCompile(`\.mp4\.part-(?:Frag)?\d+\.part$`)
 	lowerQualityRe := regexp.MustCompile(`\.(720p|480p)\.mp4$`)
+	lowerQualityTempRe := regexp.MustCompile(`\.(720p|480p)\.temp\.mp4$`)
 	channelRe := regexp.MustCompile(`^\[([^\]]+)\] ?`)
 	formatSegmentRe := regexp.MustCompile(`\.f\d{3}$`)
 
@@ -39,6 +40,15 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 		if m := lowerQualityRe.FindStringSubmatch(entry.Name()); m != nil {
 			base := strings.TrimSuffix(entry.Name(), "."+m[1]+".mp4") + ".mp4"
 			lowerQualityVersions[base] = append(lowerQualityVersions[base], m[1])
+		}
+	}
+
+	// pre-scan: find videos being actively recoded to a lower quality
+	recodingInProgress := map[string]bool{}
+	for _, entry := range entries {
+		if m := lowerQualityTempRe.FindStringSubmatch(entry.Name()); m != nil {
+			base := strings.TrimSuffix(entry.Name(), "."+m[1]+".temp.mp4") + ".mp4"
+			recodingInProgress[base] = true
 		}
 	}
 
@@ -74,6 +84,10 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 		if lowerQualityRe.MatchString(entry.Name()) {
 			continue
 		}
+		// skip lower quality temp files, e.g. "video.720p.temp.mp4" — recode in progress
+		if lowerQualityTempRe.MatchString(entry.Name()) {
+			continue
+		}
 		status := "Ready"
 		if ext == ".part" {
 			// only include the largest part file per base (skip smaller format segments)
@@ -102,6 +116,10 @@ func (vr *VideoReader) GetVideos() ([]Video, error) {
 			// if a temp file exists alongside the final mp4, mark as Processing
 			base, _ := strings.CutSuffix(entry.Name(), ".mp4")
 			if _, err := fs.Stat(vr.fs, base+".temp.mp4"); err == nil {
+				status = "Processing"
+			}
+			// if a lower quality recode is in progress, mark as Processing
+			if recodingInProgress[entry.Name()] {
 				status = "Processing"
 			}
 		}

--- a/backend/video_reader_test.go
+++ b/backend/video_reader_test.go
@@ -201,29 +201,15 @@ func TestGetVideos_Mp4With720pAnd480p_ReturnsOriginalWithBothInVersions(t *testi
 	require.Len(t, videos, 1)
 	assert.Equal(t, "video.mp4", videos[0].Filename)
 	assert.ElementsMatch(t, []VideoVersion{
-		{ID: vid.FromFilename("video.720p.mp4"), Name: "video 720p", Filename: "video.720p.mp4"},
-		{ID: vid.FromFilename("video.480p.mp4"), Name: "video 480p", Filename: "video.480p.mp4"},
+		{ID: vid.FromFilename("video.720p.mp4"), Name: "video 720p", Filename: "video.720p.mp4", Quality: "720p"},
+		{ID: vid.FromFilename("video.480p.mp4"), Name: "video 480p", Filename: "video.480p.mp4", Quality: "480p"},
 	}, videos[0].Versions)
 }
 
-func TestGetVideos_Mp4With720pTempFile_ReturnsMp4AsReadyWithNoVersions(t *testing.T) {
+func TestGetVideos_Mp4WithQualityTempFile_ReturnsMp4AsReadyWithNoVersions(t *testing.T) {
 	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4":           &fstest.MapFile{},
 		"video.720p.temp.mp4": &fstest.MapFile{},
-	})
-
-	videos, err := vr.GetVideos()
-
-	require.NoError(t, err)
-	require.Len(t, videos, 1)
-	assert.Equal(t, "video.mp4", videos[0].Filename)
-	assert.Equal(t, "Ready", videos[0].Status)
-	assert.Empty(t, videos[0].Versions)
-}
-
-func TestGetVideos_Mp4With480pTempFile_ReturnsMp4AsReadyWithNoVersions(t *testing.T) {
-	vr, _ := setupVideoReader(t, fstest.MapFS{
-		"video.mp4":           &fstest.MapFile{},
 		"video.480p.temp.mp4": &fstest.MapFile{},
 	})
 

--- a/backend/video_reader_test.go
+++ b/backend/video_reader_test.go
@@ -202,7 +202,7 @@ func TestGetVideos_Mp4With720pAnd480p_ReturnsOriginalWithBothInVersions(t *testi
 	assert.ElementsMatch(t, []string{"720p", "480p"}, videos[0].Versions)
 }
 
-func TestGetVideos_Mp4With720pTempFile_ReturnsMp4AsProcessingWithNoVersions(t *testing.T) {
+func TestGetVideos_Mp4With720pTempFile_ReturnsMp4AsReadyWithNoVersions(t *testing.T) {
 	vr := setupVideoReader(t, fstest.MapFS{
 		"video.mp4":           &fstest.MapFile{},
 		"video.720p.temp.mp4": &fstest.MapFile{},
@@ -213,7 +213,7 @@ func TestGetVideos_Mp4With720pTempFile_ReturnsMp4AsProcessingWithNoVersions(t *t
 	require.NoError(t, err)
 	require.Len(t, videos, 1)
 	assert.Equal(t, "video.mp4", videos[0].Filename)
-	assert.Equal(t, "Processing", videos[0].Status)
+	assert.Equal(t, "Ready", videos[0].Status)
 	assert.Empty(t, videos[0].Versions)
 }
 

--- a/backend/video_reader_test.go
+++ b/backend/video_reader_test.go
@@ -187,6 +187,48 @@ func TestGetVideos_TwoFormatSegmentsWithTempMp4_ReturnsSingleProcessingVideo(t *
 	assert.Equal(t, "Processing", videos[0].Status)
 }
 
+func TestGetVideos_Mp4With720pAnd480p_ReturnsOriginalWithBothInVersions(t *testing.T) {
+	vr := setupVideoReader(t, fstest.MapFS{
+		"video.mp4":      &fstest.MapFile{},
+		"video.720p.mp4": &fstest.MapFile{},
+		"video.480p.mp4": &fstest.MapFile{},
+	})
+
+	videos, err := vr.GetVideos()
+
+	require.NoError(t, err)
+	require.Len(t, videos, 1)
+	assert.Equal(t, "video.mp4", videos[0].Filename)
+	assert.ElementsMatch(t, []string{"720p", "480p"}, videos[0].Versions)
+}
+
+func TestGetVideos_Mp4With720pTempFile_ReturnsMp4AsProcessingWithNoVersions(t *testing.T) {
+	vr := setupVideoReader(t, fstest.MapFS{
+		"video.mp4":           &fstest.MapFile{},
+		"video.720p.temp.mp4": &fstest.MapFile{},
+	})
+
+	videos, err := vr.GetVideos()
+
+	require.NoError(t, err)
+	require.Len(t, videos, 1)
+	assert.Equal(t, "video.mp4", videos[0].Filename)
+	assert.Equal(t, "Processing", videos[0].Status)
+	assert.Empty(t, videos[0].Versions)
+}
+
+func TestGetVideos_Mp4Without720p_ReturnsEmptyVersions(t *testing.T) {
+	vr := setupVideoReader(t, fstest.MapFS{
+		"video.mp4": &fstest.MapFile{},
+	})
+
+	videos, err := vr.GetVideos()
+
+	require.NoError(t, err)
+	require.Len(t, videos, 1)
+	assert.Empty(t, videos[0].Versions)
+}
+
 func TestGetVideos_Mp4File_ReturnsStatusReady(t *testing.T) {
 	vr := setupVideoReader(t, fstest.MapFS{
 		"video.mp4": &fstest.MapFile{},

--- a/backend/video_reader_test.go
+++ b/backend/video_reader_test.go
@@ -201,8 +201,8 @@ func TestGetVideos_Mp4With720pAnd480p_ReturnsOriginalWithBothInVersions(t *testi
 	require.Len(t, videos, 1)
 	assert.Equal(t, "video.mp4", videos[0].Filename)
 	assert.ElementsMatch(t, []VideoVersion{
-		{ID: vid.FromFilename("video.720p.mp4"), Name: "video", Filename: "video.720p.mp4"},
-		{ID: vid.FromFilename("video.480p.mp4"), Name: "video", Filename: "video.480p.mp4"},
+		{ID: vid.FromFilename("video.720p.mp4"), Name: "video 720p", Filename: "video.720p.mp4"},
+		{ID: vid.FromFilename("video.480p.mp4"), Name: "video 480p", Filename: "video.480p.mp4"},
 	}, videos[0].Versions)
 }
 
@@ -210,6 +210,21 @@ func TestGetVideos_Mp4With720pTempFile_ReturnsMp4AsReadyWithNoVersions(t *testin
 	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4":           &fstest.MapFile{},
 		"video.720p.temp.mp4": &fstest.MapFile{},
+	})
+
+	videos, err := vr.GetVideos()
+
+	require.NoError(t, err)
+	require.Len(t, videos, 1)
+	assert.Equal(t, "video.mp4", videos[0].Filename)
+	assert.Equal(t, "Ready", videos[0].Status)
+	assert.Empty(t, videos[0].Versions)
+}
+
+func TestGetVideos_Mp4With480pTempFile_ReturnsMp4AsReadyWithNoVersions(t *testing.T) {
+	vr, _ := setupVideoReader(t, fstest.MapFS{
+		"video.mp4":           &fstest.MapFile{},
+		"video.480p.temp.mp4": &fstest.MapFile{},
 	})
 
 	videos, err := vr.GetVideos()

--- a/backend/video_reader_test.go
+++ b/backend/video_reader_test.go
@@ -10,20 +10,21 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
-func setupVideoReader(t *testing.T, fsys fstest.MapFS) *VideoReader {
+func setupVideoReader(t *testing.T, fsys fstest.MapFS) (*VideoReader, *VideoID) {
 	var vr *VideoReader
+	var vid *VideoID
 	app := fxtest.New(t,
 		CoreProviders(),
 		fx.Decorate(func() StreamsFS { return StreamsFS(fsys) }),
-		fx.Populate(&vr),
+		fx.Populate(&vr, &vid),
 	)
 	app.RequireStart()
 	t.Cleanup(func() { app.RequireStop() })
-	return vr
+	return vr, vid
 }
 
 func TestGetVideos_PartFile_ReturnsStatusDownloading(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video2026-04-04 17_55.mp4.part": &fstest.MapFile{},
 	})
 
@@ -35,7 +36,7 @@ func TestGetVideos_PartFile_ReturnsStatusDownloading(t *testing.T) {
 }
 
 func TestGetVideos_TwoPartFiles_ReturnsOnlyLargerWithStatusDownloading(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video2026-04-04 17_55.f140.webm.part": &fstest.MapFile{Data: make([]byte, 100)},
 		"video2026-04-04 17_55.f251.webm.part": &fstest.MapFile{Data: make([]byte, 200)},
 	})
@@ -49,7 +50,7 @@ func TestGetVideos_TwoPartFiles_ReturnsOnlyLargerWithStatusDownloading(t *testin
 }
 
 func TestGetVideos_FormatSegmentMp4_IsSkipped(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.f140.mp4": &fstest.MapFile{},
 	})
 
@@ -60,7 +61,7 @@ func TestGetVideos_FormatSegmentMp4_IsSkipped(t *testing.T) {
 }
 
 func TestGetVideos_TempMp4WithFinalMp4_TempIsSkipped(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4":      &fstest.MapFile{},
 		"video.temp.mp4": &fstest.MapFile{},
 	})
@@ -73,7 +74,7 @@ func TestGetVideos_TempMp4WithFinalMp4_TempIsSkipped(t *testing.T) {
 }
 
 func TestGetVideos_Mp4WithTempMp4_ReturnsStatusProcessing(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4":      &fstest.MapFile{},
 		"video.temp.mp4": &fstest.MapFile{},
 	})
@@ -87,7 +88,7 @@ func TestGetVideos_Mp4WithTempMp4_ReturnsStatusProcessing(t *testing.T) {
 }
 
 func TestGetVideos_PartXxFileWithSourceMp4_PartIsSkipped(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4":         &fstest.MapFile{},
 		"video part01.mp4":  &fstest.MapFile{},
 	})
@@ -100,7 +101,7 @@ func TestGetVideos_PartXxFileWithSourceMp4_PartIsSkipped(t *testing.T) {
 }
 
 func TestGetVideos_Mp4WithPartXxFiles_ReturnsStatusProcessing(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4":        &fstest.MapFile{},
 		"video part01.mp4": &fstest.MapFile{},
 	})
@@ -113,7 +114,7 @@ func TestGetVideos_Mp4WithPartXxFiles_ReturnsStatusProcessing(t *testing.T) {
 }
 
 func TestGetVideos_FragmentPartFile_IsSkipped(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"[Channel] Video Title.f140.mp4.part-Frag12899.part": &fstest.MapFile{},
 	})
 
@@ -124,7 +125,7 @@ func TestGetVideos_FragmentPartFile_IsSkipped(t *testing.T) {
 }
 
 func TestGetVideos_RumbleDownloadingFiles_ReturnsOnlyMainPartAsDownloading(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4.part":              &fstest.MapFile{Data: make([]byte, 500)},
 		"video.mp4.part-Frag154.part": &fstest.MapFile{Data: make([]byte, 100)},
 	})
@@ -138,7 +139,7 @@ func TestGetVideos_RumbleDownloadingFiles_ReturnsOnlyMainPartAsDownloading(t *te
 }
 
 func TestGetVideos_MixedFiles_ReturnsCorrectVideosAndStatuses(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		// ready
 		"ready.mp4": &fstest.MapFile{},
 		// downloading — two format parts, only larger returned
@@ -173,7 +174,7 @@ func TestGetVideos_MixedFiles_ReturnsCorrectVideosAndStatuses(t *testing.T) {
 }
 
 func TestGetVideos_TwoFormatSegmentsWithTempMp4_ReturnsSingleProcessingVideo(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.f140.mp4": &fstest.MapFile{},
 		"video.f251.mp4": &fstest.MapFile{},
 		"video.temp.mp4": &fstest.MapFile{},
@@ -188,7 +189,7 @@ func TestGetVideos_TwoFormatSegmentsWithTempMp4_ReturnsSingleProcessingVideo(t *
 }
 
 func TestGetVideos_Mp4With720pAnd480p_ReturnsOriginalWithBothInVersions(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, vid := setupVideoReader(t, fstest.MapFS{
 		"video.mp4":      &fstest.MapFile{},
 		"video.720p.mp4": &fstest.MapFile{},
 		"video.480p.mp4": &fstest.MapFile{},
@@ -199,11 +200,14 @@ func TestGetVideos_Mp4With720pAnd480p_ReturnsOriginalWithBothInVersions(t *testi
 	require.NoError(t, err)
 	require.Len(t, videos, 1)
 	assert.Equal(t, "video.mp4", videos[0].Filename)
-	assert.ElementsMatch(t, []string{"720p", "480p"}, videos[0].Versions)
+	assert.ElementsMatch(t, []VideoVersion{
+		{ID: vid.FromFilename("video.720p.mp4"), Name: "video", Filename: "video.720p.mp4"},
+		{ID: vid.FromFilename("video.480p.mp4"), Name: "video", Filename: "video.480p.mp4"},
+	}, videos[0].Versions)
 }
 
 func TestGetVideos_Mp4With720pTempFile_ReturnsMp4AsReadyWithNoVersions(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4":           &fstest.MapFile{},
 		"video.720p.temp.mp4": &fstest.MapFile{},
 	})
@@ -218,7 +222,7 @@ func TestGetVideos_Mp4With720pTempFile_ReturnsMp4AsReadyWithNoVersions(t *testin
 }
 
 func TestGetVideos_Mp4Without720p_ReturnsEmptyVersions(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4": &fstest.MapFile{},
 	})
 
@@ -230,7 +234,7 @@ func TestGetVideos_Mp4Without720p_ReturnsEmptyVersions(t *testing.T) {
 }
 
 func TestGetVideos_Mp4File_ReturnsStatusReady(t *testing.T) {
-	vr := setupVideoReader(t, fstest.MapFS{
+	vr, _ := setupVideoReader(t, fstest.MapFS{
 		"video.mp4": &fstest.MapFile{},
 	})
 

--- a/backend/video_response.go
+++ b/backend/video_response.go
@@ -7,5 +7,6 @@ type VideoResponse struct {
 	Name    string    `json:"name"`
 	Channel string    `json:"channel"`
 	Date    time.Time `json:"date"`
-	Status  string    `json:"status"`
+	Status   string    `json:"status"`
+	Versions []VideoVersion `json:"versions"`
 }

--- a/backend/video_store.go
+++ b/backend/video_store.go
@@ -3,13 +3,15 @@ package main
 import "sync"
 
 type VideoStore struct {
-	Videos    []Video
-	VideosMap map[string]Video
-	Mutex     sync.RWMutex
+	Videos          []Video
+	VideosMap       map[string]Video
+	VideoVersionsMap map[string]VideoVersion
+	Mutex           sync.RWMutex
 }
 
 func NewVideoStore() *VideoStore {
 	return &VideoStore{
-		VideosMap: make(map[string]Video),
+		VideosMap:       make(map[string]Video),
+		VideoVersionsMap: make(map[string]VideoVersion),
 	}
 }

--- a/backend/video_version.go
+++ b/backend/video_version.go
@@ -1,0 +1,7 @@
+package main
+
+type VideoVersion struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Filename string `json:"filename"`
+}

--- a/backend/video_version.go
+++ b/backend/video_version.go
@@ -4,4 +4,5 @@ type VideoVersion struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`
 	Filename string `json:"filename"`
+	Quality  string `json:"quality"`
 }

--- a/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
@@ -66,12 +66,12 @@ export default function VideoListItem({ video, isSelected, videoCountVisible, on
                 <DropdownMenuTrigger className="rounded hover:bg-gray-200 flex-shrink-0 cursor-pointer">
                     <EllipsisVertical className="w-4 h-4 text-gray-500" />
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-56">
+                <DropdownMenuContent align="end" className="min-w-45">
                     <DropdownMenuItem disabled={video.status !== 'Ready'}>
                         <a
                             href={`${API_URL}/download/${video.id}`}
                             download={`${video.name}.mp4`}
-                            className="contents"
+                            className="w-full flex items-center gap-2"
                         >
                             <Download className="w-4 h-4 shrink-0" />
                             Download Max
@@ -79,7 +79,7 @@ export default function VideoListItem({ video, isSelected, videoCountVisible, on
                     </DropdownMenuItem>
                     {[...(video.versions ?? [])].sort((a, b) => (parseInt(b.quality) || 0) - (parseInt(a.quality) || 0)).map(v => (
                         <DropdownMenuItem key={v.id}>
-                            <a href={`${API_URL}/download/${v.id}`} download={v.filename} className="contents">
+                            <a href={`${API_URL}/download/${v.id}`} download={v.filename} className="w-full flex items-center gap-2">
                                 <Download className="w-4 h-4 shrink-0" />
                                 Download {v.quality}
                             </a>

--- a/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
@@ -1,6 +1,5 @@
-import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { EllipsisVertical, Download, X, RotateCcw } from 'lucide-react'
+import { EllipsisVertical, Download, RotateCcw } from 'lucide-react'
 import { formatDistanceToNow, format } from 'date-fns'
 import {
     DropdownMenu,
@@ -12,17 +11,7 @@ import {
 
 const API_URL = import.meta.env.VITE_API_URL
 
-function getDownloadInfo(id) {
-    const raw = localStorage.getItem(`download_${id}`)
-    return raw ? JSON.parse(raw) : null
-}
-
-function saveDownloadInfo(id, filename) {
-    localStorage.setItem(`download_${id}`, JSON.stringify({ filename }))
-}
-
 export default function VideoListItem({ video, isSelected, videoCountVisible, onWatchedReset, playlistVideos }) {
-    const [downloadInfo, setDownloadInfo] = useState(getDownloadInfo(video.id))
 
     const progressSavedTime = playlistVideos
         ? playlistVideos.reduce((sum, v) => sum + (parseFloat(v.savedTime) || 0), 0)
@@ -82,20 +71,20 @@ export default function VideoListItem({ video, isSelected, videoCountVisible, on
                         <a
                             href={`${API_URL}/download/${video.id}`}
                             download={`${video.name}.mp4`}
-                            onClick={() => { saveDownloadInfo(video.id, `${video.name}.mp4`); setDownloadInfo(getDownloadInfo(video.id)) }}
                             className="contents"
                         >
                             <Download className="w-4 h-4 shrink-0" />
-                            {downloadInfo ? 'Download again' : 'Download'}
+                            Download Max
                         </a>
                     </DropdownMenuItem>
-                    <DropdownMenuItem
-                        disabled={!downloadInfo}
-                        onClick={() => { localStorage.removeItem(`download_${video.id}`); setDownloadInfo(null) }}
-                    >
-                        <X className="w-4 h-4 shrink-0" />
-                        Reset Download Info
-                    </DropdownMenuItem>
+                    {[...(video.versions ?? [])].sort((a, b) => (parseInt(b.quality) || 0) - (parseInt(a.quality) || 0)).map(v => (
+                        <DropdownMenuItem key={v.id}>
+                            <a href={`${API_URL}/download/${v.id}`} download={v.filename} className="contents">
+                                <Download className="w-4 h-4 shrink-0" />
+                                Download {v.quality}
+                            </a>
+                        </DropdownMenuItem>
+                    ))}
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
                         disabled={!progressSavedTime}


### PR DESCRIPTION
Closes #5

## Summary
- Adds a lower quality recode worker that produces 720p and 480p versions of uploaded videos
- Exposes `VideoVersion` (ID, name, filename, quality) in the API and per-quality download buttons in the UI
- Makes recode qualities configurable via config and refactors workers to process one item per loop iteration

## Test plan
- [x] Upload a video and verify 720p and 480p versions appear with per-quality download buttons
- [x] Check config-driven quality settings work end-to-end
- [x] Confirm original video stays in Ready state while recode is in progress
- [x] Verify temp files are not deleted on recode failure
- [x] Run test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)