### PR TITLE
Change page title to currently playing video name

### DIFF
--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -117,6 +117,7 @@ export default function Home() {
 
     useEffect(() => {
         if (!selectedVideo) return
+        document.title = selectedVideo.name
         if ('mediaSession' in navigator) {
             navigator.mediaSession.metadata = new MediaMetadata({
                 title: selectedVideo.name,


### PR DESCRIPTION
Closes #34

## Summary
- Sets `document.title` to the selected video's name whenever the active video changes.

## Test plan
- [ ] Open the app and navigate between videos — browser tab title should update to the video name.