### PR TITLE
Remove fixed-width padding from streamer field in log format

### DIFF
--- a/downloader/config.toml
+++ b/downloader/config.toml
@@ -1,5 +1,5 @@
 output_folder = "d:/streams"
-log_format = "<green>{time}</green> | <level>{level:<5}</level> | <cyan>{name}:{function}:{line:<4}</cyan> | <magenta>{extra[streamer]:<15}</magenta> | <level>{message}</level>"
+log_format = "<green>{time}</green> | <level>{level:<5}</level> | <cyan>{name}:{function}:{line:<4}</cyan> | <magenta>{extra[streamer]}</magenta> | <level>{message}</level>"
 
 [[channels]]
 id = "UCUyeluBRhGPCW4rPe_UvBZQ"


### PR DESCRIPTION
Closes #31

## Summary
- Removes `:<15` width specifier from `{extra[streamer]}` in the loguru format string in `config.toml`, eliminating the trailing spaces printed after short streamer names.

## Test plan
- [ ] Start the downloader and observe log output — streamer column should no longer have trailing whitespace padding.