### PR TITLE
Save video time to localStorage when seeking with arrow keys

### DIFF
--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -47,6 +47,16 @@ export default function Home() {
 
     const selectedVideo = useMemo(() => videos.find(v => v.id === id), [videos, id])
 
+    function saveWatchedTime(t) {
+        localStorage.setItem(`time_${selectedVideo.id}`, t)
+        setSearchParams({ t }, { replace: true })
+        setVideos(prev => {
+            const v = prev.find(v => v.id === selectedVideo.id)
+            if (v) v.savedTime = t
+            return [...prev]
+        })
+    }
+
     function handleWatchedReset(video, updateVideos = true) {
         localStorage.removeItem(`time_${video.id}`)
         video.savedTime = null
@@ -191,16 +201,15 @@ export default function Home() {
                                         autoPlay
                                         playsInline
                                         onTimeUpdate={e => {
-                                            const t = Math.floor(e.target.currentTime)
+                                            const t = Math.round(e.target.currentTime)
                                             if (t % 5 !== 0) return
                                             if (t === parseInt(searchParams.get('t'))) return
-                                            localStorage.setItem(`time_${selectedVideo.id}`, t)
-                                            setSearchParams({ t }, { replace: true })
-                                            setVideos(prev => {
-                                                const v = prev.find(v => v.id === selectedVideo.id)
-                                                if (v) v.savedTime = t
-                                                return [...prev]
-                                            })
+                                            saveWatchedTime(t)
+                                        }}
+                                        onSeeked={e => {
+                                            const t = Math.round(e.target.currentTime)
+                                            if (t === parseInt(searchParams.get('t'))) return
+                                            saveWatchedTime(t)
                                         }}
                                         onLoadedMetadata={e => {
                                             const t = searchParams.get('t')


### PR DESCRIPTION
Closes #35

## Summary
- Added `saveWatchedTime` helper to deduplicate time-saving logic.
- Added `onSeeked` handler on the video element so any seek (arrow keys, scrubber) immediately saves the time to localStorage and updates the URL — no more waiting for the next multiple-of-5 second mark.
- `onTimeUpdate` continues saving every 5 seconds during normal playback.

## Test plan
- [ ] Load a video at a non-multiple-of-5 timestamp (e.g. `?t=9543`), press ArrowRight/ArrowLeft — URL param `t` and localStorage should update immediately.
- [ ] Normal playback still saves every 5 seconds as before.
- [ ] Scrubbing the progress bar also saves immediately.