### PR TITLE
Configure yt-dlp to use Node.js as JS runtime for YouTube extraction (#53)

### DIFF
--- a/downloader/youtube_live_downloader.py
+++ b/downloader/youtube_live_downloader.py
@@ -29,6 +29,7 @@ class YoutubeLiveDownloader(Downloader):
             ydl_opts = {
                 **SHARED_YT_DLP_SETTINGS,
                 "logger": yt_dlp_logger,
+                "js_runtimes": {"node": {}},
                 "format": "bestvideo+bestaudio/best",
                 # CRITICAL: This flag tells yt-dlp to start from the beginning of the DVR
                 "live_from_start": True,

--- a/downloader/youtube_video_downloader.py
+++ b/downloader/youtube_video_downloader.py
@@ -29,6 +29,7 @@ class YoutubeVideoDownloader(Downloader):
             ydl_opts = {
                 **SHARED_YT_DLP_SETTINGS,
                 "logger": yt_dlp_logger,
+                "js_runtimes": {"node": {}},
                 "format": "bestvideo[vcodec^=avc1]+bestaudio[acodec^=mp4a]/bestvideo[vcodec^=avc1]+bestaudio/bestvideo+bestaudio/best",
                 "merge_output_format": "mp4",
                 "overwrites": False,


### PR DESCRIPTION
## Summary
- Sets `js_runtimes: {"node": {}}` in both `YoutubeLiveDownloader` and `YoutubeVideoDownloader` yt-dlp options
- Eliminates the deprecation warning about missing JS runtime during YouTube extraction

## Test plan
- [x] Confirmed warning no longer appears when downloading a YouTube video

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)