### PR TITLE
Decrease top bar height on phones (landscape and portrait)

### DIFF
--- a/frontend/src/components/frontend/Logo/Logo.jsx
+++ b/frontend/src/components/frontend/Logo/Logo.jsx
@@ -2,9 +2,10 @@ import { Tv } from 'lucide-react'
 
 export default function Logo({ color = 'text-white' }) {
     return (
-        <div className="flex items-center gap-3">
-            <Tv size={24} className={`${color} -mt-1`} />
-            <span className={`${color} text-xl font-bold tracking-wide`}>Watch</span>
+        <div className="flex items-center gap-2 lg:gap-3">
+            <Tv size={20} className={`${color} -mt-1 lg:hidden`} />
+            <Tv size={24} className={`${color} -mt-1 hidden lg:block`} />
+            <span className={`${color} text-base lg:text-xl font-bold tracking-wide`}>Watch</span>
         </div>
     )
 }

--- a/frontend/src/components/frontend/SidebarTrigger/SidebarTrigger.jsx
+++ b/frontend/src/components/frontend/SidebarTrigger/SidebarTrigger.jsx
@@ -14,8 +14,9 @@ export default function SidebarTrigger({ className = 'text-white' }) {
     }, [open, setOpen])
 
     return (
-        <button onClick={toggleSidebar} className={`md:pr-3 ${className}`}>
-            <MenuIcon size={24} />
+        <button onClick={toggleSidebar} className={`lg:pr-3 ${className}`}>
+            <MenuIcon size={20} className="lg:hidden" />
+            <MenuIcon size={24} className="hidden lg:block" />
         </button>
     )
 }

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -181,7 +181,7 @@ export default function Home() {
                 <div className="flex flex-col">
 
                     {/* Top */}
-                    <div className="bg-gray-900 px-6 py-4 flex items-center gap-3">
+                    <div className="bg-gray-900 px-3 py-2 lg:px-6 lg:py-4 flex items-center gap-3">
                         <SidebarTrigger />
                         <Logo />
                         <SearchBar videos={videos} />


### PR DESCRIPTION
Closes #26

## Summary
- Use `lg:` breakpoint for top bar padding, logo size, and hamburger icon
- Phones in both portrait and landscape get a compact header; desktop gets the original larger header

## Test plan
- [ ] Phone portrait: top bar is compact
- [ ] Phone landscape: top bar is compact (not switching to large)
- [ ] Desktop (1024px+): top bar is full size with gap after hamburger

🤖 Generated with [Claude Code](https://claude.com/claude-code)