### PR TITLE
Add button to mark video as watched

### DIFF
--- a/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { EllipsisVertical, Download, RotateCcw } from 'lucide-react'
+import { EllipsisVertical, Download, RotateCcw, CheckCheck } from 'lucide-react'
 import { formatDistanceToNow, format } from 'date-fns'
 import {
     DropdownMenu,
@@ -11,7 +11,7 @@ import {
 
 const API_URL = import.meta.env.VITE_API_URL
 
-export default function VideoListItem({ video, isSelected, videoCountVisible, onWatchedReset, playlistVideos }) {
+export default function VideoListItem({ video, isSelected, videoCountVisible, onWatchedReset, onWatchedMark, playlistVideos }) {
 
     const progressSavedTime = playlistVideos
         ? playlistVideos.reduce((sum, v) => sum + (parseFloat(v.savedTime) || 0), 0)
@@ -86,6 +86,13 @@ export default function VideoListItem({ video, isSelected, videoCountVisible, on
                         </DropdownMenuItem>
                     ))}
                     <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                        disabled={!progressDuration}
+                        onClick={() => onWatchedMark?.(video)}
+                    >
+                        <CheckCheck className="w-4 h-4 shrink-0" />
+                        Mark as Watched
+                    </DropdownMenuItem>
                     <DropdownMenuItem
                         disabled={!progressSavedTime}
                         onClick={() => onWatchedReset?.(video)}

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -58,7 +58,7 @@ export default function Home() {
     }
 
     function handleWatchedMark(video, updateVideos = true) {
-        const t = Math.round(video.duration)
+        const t = video.duration
         if (!t) return
         localStorage.setItem(`time_${video.id}`, t)
         video.savedTime = t

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -57,6 +57,18 @@ export default function Home() {
         })
     }
 
+    function handleWatchedMark(video, updateVideos = true) {
+        const t = Math.round(video.duration)
+        if (!t) return
+        localStorage.setItem(`time_${video.id}`, t)
+        video.savedTime = t
+        if (updateVideos) setVideos(prev => [...prev])
+        if (video.id === id) {
+            videoRef.current.currentTime = t
+            setSearchParams({ t }, { replace: true })
+        }
+    }
+
     function handleWatchedReset(video, updateVideos = true) {
         localStorage.removeItem(`time_${video.id}`)
         video.savedTime = null
@@ -248,6 +260,7 @@ export default function Home() {
                                             video={video}
                                             isSelected={selectedVideo?.id === video.id}
                                             onWatchedReset={handleWatchedReset}
+                                            onWatchedMark={handleWatchedMark}
                                         />
                                     ))}
                                 </div>
@@ -260,6 +273,11 @@ export default function Home() {
                                     isSelected={selectedVideo?.id === video.id || playlist.some(v => v.id === video.id)}
                                     videoCountVisible
                                     playlistVideos={playlists.find(p => p.some(pv => pv.id === video.id)) ?? null}
+                                    onWatchedMark={v => {
+                                        const pl = playlists.find(p => p.some(pv => pv.id === v.id)) ?? [v]
+                                        pl.forEach(pv => handleWatchedMark(pv, false))
+                                        setVideos(prev => [...prev])
+                                    }}
                                     onWatchedReset={v => {
                                         const pl = playlists.find(p => p.some(pv => pv.id === v.id)) ?? [v]
                                         pl.forEach(pv => handleWatchedReset(pv, false))


### PR DESCRIPTION
Closes #3

## Summary
- Added "Mark as Watched" option to the video dropdown menu
- For playlist items in the videos list, marks all parts as watched
- Sets savedTime to the video duration and seeks the currently playing video to the end

## Test plan
- [ ] Single video: "Mark as Watched" fills the progress bar to 100%
- [ ] Playlist item: "Mark as Watched" marks all parts as watched
- [ ] Currently playing video: seeking jumps to the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)