### PR TITLE
Move _progress_buffer init to __init__ in YtDlpLogger

### DIFF
--- a/downloader/yt_dlp_logger.py
+++ b/downloader/yt_dlp_logger.py
@@ -10,10 +10,10 @@ class YtDlpLogger:
     @inject
     def __init__(self):
         self._log = logger.bind(streamer="-")
+        self._progress_buffer: list[str] = []
 
     def set_streamer(self, streamer: str):
         self._log = logger.bind(streamer=streamer)
-        self._progress_buffer: list[str] = []
 
     # Stack when called directly (no _buffer_or_log layer):
     #   [0] _depth  [1] debug  [2] yt-dlp caller  → start=2


### PR DESCRIPTION
Closes #51

## Summary
- `_progress_buffer` was initialized in `set_streamer` instead of `__init__`, causing a potential `AttributeError` if any progress hook fired before `set_streamer` was called
- Moved initialization to `__init__` alongside `_log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)