### PR TITLE
Enable yt-dlp remote component EJS for YouTube n challenge solving

### DIFF
--- a/downloader/youtube_live_downloader.py
+++ b/downloader/youtube_live_downloader.py
@@ -30,7 +30,7 @@ class YoutubeLiveDownloader(Downloader):
                 **SHARED_YT_DLP_SETTINGS,
                 "logger": yt_dlp_logger,
                 "js_runtimes": {"node": {}},
-                "remote_components": "ejs:github",
+                "remote_components": ["ejs:github"],
                 "format": "bestvideo+bestaudio/best",
                 # CRITICAL: This flag tells yt-dlp to start from the beginning of the DVR
                 "live_from_start": True,

--- a/downloader/youtube_live_downloader.py
+++ b/downloader/youtube_live_downloader.py
@@ -30,6 +30,7 @@ class YoutubeLiveDownloader(Downloader):
                 **SHARED_YT_DLP_SETTINGS,
                 "logger": yt_dlp_logger,
                 "js_runtimes": {"node": {}},
+                "remote_components": "ejs:github",
                 "format": "bestvideo+bestaudio/best",
                 # CRITICAL: This flag tells yt-dlp to start from the beginning of the DVR
                 "live_from_start": True,

--- a/downloader/youtube_video_downloader.py
+++ b/downloader/youtube_video_downloader.py
@@ -30,7 +30,7 @@ class YoutubeVideoDownloader(Downloader):
                 **SHARED_YT_DLP_SETTINGS,
                 "logger": yt_dlp_logger,
                 "js_runtimes": {"node": {}},
-                "remote_components": "ejs:github",
+                "remote_components": ["ejs:github"],
                 "format": "bestvideo[vcodec^=avc1]+bestaudio[acodec^=mp4a]/bestvideo[vcodec^=avc1]+bestaudio/bestvideo+bestaudio/best",
                 "merge_output_format": "mp4",
                 "overwrites": False,

--- a/downloader/youtube_video_downloader.py
+++ b/downloader/youtube_video_downloader.py
@@ -30,6 +30,7 @@ class YoutubeVideoDownloader(Downloader):
                 **SHARED_YT_DLP_SETTINGS,
                 "logger": yt_dlp_logger,
                 "js_runtimes": {"node": {}},
+                "remote_components": "ejs:github",
                 "format": "bestvideo[vcodec^=avc1]+bestaudio[acodec^=mp4a]/bestvideo[vcodec^=avc1]+bestaudio/bestvideo+bestaudio/best",
                 "merge_output_format": "mp4",
                 "overwrites": False,


### PR DESCRIPTION
Closes #60

## Summary
- Added `remote_components: ejs:github` to both `youtube_live_downloader.py` and `youtube_video_downloader.py`
- Fixes yt-dlp n challenge solving failures that caused some formats to go missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)