### PR TITLE
Disable Mark as Watched and Reset Watched when video is not Ready

### DIFF
--- a/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
@@ -87,14 +87,14 @@ export default function VideoListItem({ video, isSelected, videoCountVisible, on
                     ))}
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
-                        disabled={!progressDuration}
+                        disabled={video.status !== 'Ready'}
                         onClick={() => onWatchedMark?.(video)}
                     >
                         <CheckCheck className="w-4 h-4 shrink-0" />
                         Mark as Watched
                     </DropdownMenuItem>
                     <DropdownMenuItem
-                        disabled={!progressSavedTime}
+                        disabled={video.status !== 'Ready'}
                         onClick={() => onWatchedReset?.(video)}
                     >
                         <RotateCcw className="w-4 h-4 shrink-0" />


### PR DESCRIPTION
Closes #3

## Summary
- Changed `disabled` condition on both "Mark as Watched" and "Reset Watched" to `video.status !== 'Ready'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)