### PR TITLE
Fix SidebarTrigger spacing for portrait phone (#26)

### DIFF
--- a/frontend/src/components/frontend/SidebarTrigger/SidebarTrigger.jsx
+++ b/frontend/src/components/frontend/SidebarTrigger/SidebarTrigger.jsx
@@ -14,7 +14,7 @@ export default function SidebarTrigger({ className = 'text-white' }) {
     }, [open, setOpen])
 
     return (
-        <button onClick={toggleSidebar} className={`md:pr-2 lg:pr-3 ${className}`}>
+        <button onClick={toggleSidebar} className={`md:mr-2 lg:mr-3 ${className}`}>
             <MenuIcon size={24} className="md:hidden lg:block" />
             <MenuIcon size={20} className="hidden md:block lg:hidden" />
         </button>


### PR DESCRIPTION
## Summary
- Replace `pr-*` (padding-right) with `mr-*` (margin-right) on SidebarTrigger button for correct spacing on portrait phone screens

## Test plan
- [ ] Verify sidebar trigger button spacing looks correct on portrait phone
- [ ] Verify no regression on desktop/tablet/landscape views

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)