### PR TITLE
Delete video button (#58)

### DIFF
--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -158,6 +158,19 @@ func (s *GinServer) registerRoutes() {
 			os.Rename(src, filepath.Join(deletedDir, filepath.Base(v.Filename)))
 		}
 
+		s.store.Mutex.Lock()
+		delete(s.store.VideosMap, body.ID)
+		for _, version := range v.Versions {
+			delete(s.store.VideoVersionsMap, version.ID)
+		}
+		for i, sv := range s.store.Videos {
+			if sv.ID == body.ID {
+				s.store.Videos = append(s.store.Videos[:i], s.store.Videos[i+1:]...)
+				break
+			}
+		}
+		s.store.Mutex.Unlock()
+
 		c.Status(http.StatusNoContent)
 	})
 

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -121,6 +121,46 @@ func (s *GinServer) registerRoutes() {
 		c.File(thumbPath)
 	})
 
+	s.router.POST("/delete-video", func(c *gin.Context) {
+		var body struct {
+			ID string `json:"id" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+			return
+		}
+
+		s.store.Mutex.RLock()
+		v, ok := s.store.VideosMap[body.ID]
+		s.store.Mutex.RUnlock()
+		if !ok {
+			c.Status(404)
+			return
+		}
+
+		deletedDir := filepath.Join(s.cfg.StreamsDir, "deleted")
+		if err := os.MkdirAll(deletedDir, 0755); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create deleted folder"})
+			return
+		}
+
+		// Move version files first
+		for _, version := range v.Versions {
+			src := filepath.Join(s.cfg.StreamsDir, version.Filename)
+			if _, err := os.Stat(src); err == nil {
+				os.Rename(src, filepath.Join(deletedDir, filepath.Base(version.Filename)))
+			}
+		}
+
+		// Move main video file
+		src := filepath.Join(s.cfg.StreamsDir, v.Filename)
+		if _, err := os.Stat(src); err == nil {
+			os.Rename(src, filepath.Join(deletedDir, filepath.Base(v.Filename)))
+		}
+
+		c.Status(http.StatusNoContent)
+	})
+
 	s.router.POST("/request-download", func(c *gin.Context) {
 		var body struct {
 			URL string `json:"url" binding:"required"`

--- a/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { EllipsisVertical, Download, RotateCcw, CheckCheck } from 'lucide-react'
+import { EllipsisVertical, Download, RotateCcw, CheckCheck, Trash2 } from 'lucide-react'
 import { formatDistanceToNow, format } from 'date-fns'
 import {
     DropdownMenu,
@@ -11,7 +11,7 @@ import {
 
 const API_URL = import.meta.env.VITE_API_URL
 
-export default function VideoListItem({ video, isSelected, videoCountVisible, onWatchedReset, onWatchedMark, playlistVideos }) {
+export default function VideoListItem({ video, isSelected, videoCountVisible, onWatchedReset, onWatchedMark, onDelete, playlistVideos }) {
 
     const progressSavedTime = playlistVideos
         ? playlistVideos.reduce((sum, v) => sum + (parseFloat(v.savedTime) || 0), 0)
@@ -99,6 +99,15 @@ export default function VideoListItem({ video, isSelected, videoCountVisible, on
                     >
                         <RotateCcw className="w-4 h-4 shrink-0" />
                         Reset Watched
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                        disabled={video.status !== 'Ready'}
+                        className="text-red-600 focus:text-red-600"
+                        onClick={() => onDelete?.(video)}
+                    >
+                        <Trash2 className="w-4 h-4 shrink-0" />
+                        Delete
                     </DropdownMenuItem>
                 </DropdownMenuContent>
             </DropdownMenu>

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -69,6 +69,25 @@ export default function Home() {
         }
     }
 
+    async function handleDeleteSingle(video) {
+        await fetch(`${API_URL}/delete-video`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: video.id }),
+        })
+        setVideos(prev => prev.filter(v => v.id !== video.id))
+    }
+
+    async function handleDeletePlaylist(video) {
+        const pl = playlists.find(p => p.some(pv => pv.id === video.id)) ?? [video]
+        await Promise.allSettled(pl.map(v => fetch(`${API_URL}/delete-video`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: v.id }),
+        })))
+        setVideos(prev => prev.filter(v => !pl.some(pv => pv.id === v.id)))
+    }
+
     function handleWatchedReset(video, updateVideos = true) {
         localStorage.removeItem(`time_${video.id}`)
         video.savedTime = null
@@ -261,6 +280,7 @@ export default function Home() {
                                             isSelected={selectedVideo?.id === video.id}
                                             onWatchedReset={handleWatchedReset}
                                             onWatchedMark={handleWatchedMark}
+                                            onDelete={handleDeleteSingle}
                                         />
                                     ))}
                                 </div>
@@ -283,6 +303,7 @@ export default function Home() {
                                         pl.forEach(pv => handleWatchedReset(pv, false))
                                         setVideos(prev => [...prev])
                                     }}
+                                    onDelete={handleDeletePlaylist}
                                 />
                             ))}
                         </div>

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -43,6 +43,7 @@ export default function Home() {
     const [downloadUrl, setDownloadUrl] = useState('')
     const [downloadPending, setDownloadPending] = useState(false)
     const [downloadError, setDownloadError] = useState(false)
+    const [deleteTarget, setDeleteTarget] = useState(null)
     const videoRef = useRef(null)
 
     const selectedVideo = useMemo(() => videos.find(v => v.id === id), [videos, id])
@@ -69,17 +70,18 @@ export default function Home() {
         }
     }
 
-    async function handleDeleteSingle(video) {
-        await fetch(`${API_URL}/delete-video`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ id: video.id }),
-        })
-        setVideos(prev => prev.filter(v => v.id !== video.id))
+    function handleDeleteSingle(video) {
+        setDeleteTarget({ videos: [video] })
     }
 
-    async function handleDeletePlaylist(video) {
+    function handleDeletePlaylist(video) {
         const pl = playlists.find(p => p.some(pv => pv.id === video.id)) ?? [video]
+        setDeleteTarget({ videos: pl })
+    }
+
+    async function confirmDelete() {
+        const pl = deleteTarget.videos
+        setDeleteTarget(null)
         await Promise.allSettled(pl.map(v => fetch(`${API_URL}/delete-video`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -357,6 +359,23 @@ export default function Home() {
                                 }
                             }}
                         >Download</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+            <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Delete Video</DialogTitle>
+                        <DialogDescription>
+                            {deleteTarget?.videos.length > 1
+                                ? `Are you sure you want to delete all ${deleteTarget.videos.length} videos in this playlist? This cannot be undone.`
+                                : 'Are you sure you want to delete this video? This cannot be undone.'
+                            }
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
+                        <Button variant="destructive" onClick={confirmDelete}>Delete</Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>


### PR DESCRIPTION
Closes #58

## Summary
- Adds `POST /delete-video` backend endpoint that moves the video and its version files to a `deleted/` folder, then removes the video from the in-memory store
- Adds a Delete menu item (red, disabled when not Ready) to the video list item dropdown, with a separator above it
- Clicking Delete shows a confirmation dialog before any requests are made; playlist deletions delete all videos in the playlist, playlist item deletions delete only the single video

## Test plan
- [x] Delete a single video — files move to `deleted/`, video disappears from the list
- [ ] Delete a video with playlist parts from the videos section — all parts are deleted
- [ ] Delete a single part from the playlist section — only that part is deleted
- [x] Cancel on the confirmation dialog — nothing is deleted
- [ ] Delete button is disabled for non-Ready videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)