### PR TITLE
Extract handlers from GinServer (backend refactoring)

### DIFF
--- a/backend/delete_video_handler.go
+++ b/backend/delete_video_handler.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+)
+
+type DeleteVideoHandler struct {
+	cfg   *Config
+	store *VideoStore
+}
+
+func NewDeleteVideoHandler(cfg *Config, store *VideoStore) *DeleteVideoHandler {
+	return &DeleteVideoHandler{cfg: cfg, store: store}
+}
+
+func (h *DeleteVideoHandler) DeleteVideo(c *gin.Context) {
+	var body struct {
+		ID string `json:"id" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+		return
+	}
+
+	h.store.Mutex.RLock()
+	v, ok := h.store.VideosMap[body.ID]
+	h.store.Mutex.RUnlock()
+	if !ok {
+		c.Status(404)
+		return
+	}
+
+	deletedDir := filepath.Join(h.cfg.StreamsDir, "deleted")
+	if err := os.MkdirAll(deletedDir, 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create deleted folder"})
+		return
+	}
+
+	for _, version := range v.Versions {
+		src := filepath.Join(h.cfg.StreamsDir, version.Filename)
+		if _, err := os.Stat(src); err == nil {
+			os.Rename(src, filepath.Join(deletedDir, filepath.Base(version.Filename)))
+		}
+	}
+
+	src := filepath.Join(h.cfg.StreamsDir, v.Filename)
+	if _, err := os.Stat(src); err == nil {
+		os.Rename(src, filepath.Join(deletedDir, filepath.Base(v.Filename)))
+	}
+
+	h.store.Mutex.Lock()
+	delete(h.store.VideosMap, body.ID)
+	for _, version := range v.Versions {
+		delete(h.store.VideoVersionsMap, version.ID)
+	}
+	for i, sv := range h.store.Videos {
+		if sv.ID == body.ID {
+			h.store.Videos = append(h.store.Videos[:i], h.store.Videos[i+1:]...)
+			break
+		}
+	}
+	h.store.Mutex.Unlock()
+
+	c.Status(http.StatusNoContent)
+}

--- a/backend/download_handler.go
+++ b/backend/download_handler.go
@@ -1,0 +1,33 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+type DownloadHandler struct {
+	cfg        *Config
+	store      *VideoStore
+	fileServer *GinSharableFileServer
+}
+
+func NewDownloadHandler(cfg *Config, store *VideoStore, fileServer *GinSharableFileServer) *DownloadHandler {
+	return &DownloadHandler{cfg: cfg, store: store, fileServer: fileServer}
+}
+
+func (h *DownloadHandler) Download(c *gin.Context) {
+	id := c.Param("id")
+	h.store.Mutex.RLock()
+	v, ok := h.store.VideosMap[id]
+	vv, versionOk := h.store.VideoVersionsMap[id]
+	h.store.Mutex.RUnlock()
+	if !ok && !versionOk {
+		c.Status(404)
+		return
+	}
+	var filename string
+	if versionOk {
+		filename = vv.Filename
+	} else {
+		filename = v.Filename
+	}
+	c.Header("Content-Disposition", `attachment; filename="`+filename+`"`)
+	h.fileServer.Serve(c, h.cfg.StreamsDir+"/"+filename, filename)
+}

--- a/backend/duration_handler.go
+++ b/backend/duration_handler.go
@@ -1,0 +1,33 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+type DurationHandler struct {
+	cfg           *Config
+	store         *VideoStore
+	videoDuration *VideoDuration
+}
+
+func NewDurationHandler(cfg *Config, store *VideoStore, videoDuration *VideoDuration) *DurationHandler {
+	return &DurationHandler{cfg: cfg, store: store, videoDuration: videoDuration}
+}
+
+func (h *DurationHandler) GetDuration(c *gin.Context) {
+	id := c.Param("id")
+	h.store.Mutex.RLock()
+	v, ok := h.store.VideosMap[id]
+	h.store.Mutex.RUnlock()
+	if !ok {
+		c.Status(404)
+		return
+	}
+	duration, err := h.videoDuration.Get(h.cfg.StreamsDir + "/" + v.Filename)
+	if err != nil {
+		c.Status(500)
+		return
+	}
+	if v.Status == "Ready" {
+		c.Header("Cache-Control", "public, max-age=18000")
+	}
+	c.JSON(200, gin.H{"duration": duration})
+}

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -23,6 +23,7 @@ type GinServer struct {
 	downloadHandler        *DownloadHandler
 	durationHandler        *DurationHandler
 	thumbnailHandler       *ThumbnailHandler
+	deleteVideoHandler     *DeleteVideoHandler
 	router                 *gin.Engine
 }
 
@@ -39,6 +40,7 @@ func NewGinServer(
 	downloadHandler *DownloadHandler,
 	durationHandler *DurationHandler,
 	thumbnailHandler *ThumbnailHandler,
+	deleteVideoHandler *DeleteVideoHandler,
 ) *GinServer {
 	r := gin.Default()
 	return &GinServer{
@@ -54,6 +56,7 @@ func NewGinServer(
 		downloadHandler:        downloadHandler,
 		durationHandler:        durationHandler,
 		thumbnailHandler:       thumbnailHandler,
+		deleteVideoHandler:     deleteVideoHandler,
 		router:                 r,
 	}
 }
@@ -73,58 +76,7 @@ func (s *GinServer) registerRoutes() {
 
 	s.router.GET("/thumbnail/:id", s.thumbnailHandler.GetThumbnail)
 
-	s.router.POST("/delete-video", func(c *gin.Context) {
-		var body struct {
-			ID string `json:"id" binding:"required"`
-		}
-		if err := c.ShouldBindJSON(&body); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
-			return
-		}
-
-		s.store.Mutex.RLock()
-		v, ok := s.store.VideosMap[body.ID]
-		s.store.Mutex.RUnlock()
-		if !ok {
-			c.Status(404)
-			return
-		}
-
-		deletedDir := filepath.Join(s.cfg.StreamsDir, "deleted")
-		if err := os.MkdirAll(deletedDir, 0755); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create deleted folder"})
-			return
-		}
-
-		// Move version files first
-		for _, version := range v.Versions {
-			src := filepath.Join(s.cfg.StreamsDir, version.Filename)
-			if _, err := os.Stat(src); err == nil {
-				os.Rename(src, filepath.Join(deletedDir, filepath.Base(version.Filename)))
-			}
-		}
-
-		// Move main video file
-		src := filepath.Join(s.cfg.StreamsDir, v.Filename)
-		if _, err := os.Stat(src); err == nil {
-			os.Rename(src, filepath.Join(deletedDir, filepath.Base(v.Filename)))
-		}
-
-		s.store.Mutex.Lock()
-		delete(s.store.VideosMap, body.ID)
-		for _, version := range v.Versions {
-			delete(s.store.VideoVersionsMap, version.ID)
-		}
-		for i, sv := range s.store.Videos {
-			if sv.ID == body.ID {
-				s.store.Videos = append(s.store.Videos[:i], s.store.Videos[i+1:]...)
-				break
-			}
-		}
-		s.store.Mutex.Unlock()
-
-		c.Status(http.StatusNoContent)
-	})
+	s.router.POST("/delete-video", s.deleteVideoHandler.DeleteVideo)
 
 	s.router.POST("/request-video-download", func(c *gin.Context) {
 		var body struct {

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -23,8 +23,9 @@ type GinServer struct {
 	downloadHandler        *DownloadHandler
 	durationHandler        *DurationHandler
 	thumbnailHandler       *ThumbnailHandler
-	deleteVideoHandler     *DeleteVideoHandler
-	router                 *gin.Engine
+	deleteVideoHandler              *DeleteVideoHandler
+	requestVideoDownloadHandler     *RequestVideoDownloadHandler
+	router                          *gin.Engine
 }
 
 func NewGinServer(
@@ -41,23 +42,25 @@ func NewGinServer(
 	durationHandler *DurationHandler,
 	thumbnailHandler *ThumbnailHandler,
 	deleteVideoHandler *DeleteVideoHandler,
+	requestVideoDownloadHandler *RequestVideoDownloadHandler,
 ) *GinServer {
 	r := gin.Default()
 	return &GinServer{
-		cfg:                    cfg,
-		store:                  store,
-		filenames:              filenames,
-		videoDuration:          videoDuration,
-		fileServer:             fileServer,
-		downloadRequestService: downloadRequestService,
-		videosHandler:          videosHandler,
-		pingHandler:            pingHandler,
-		videoHandler:           videoHandler,
-		downloadHandler:        downloadHandler,
-		durationHandler:        durationHandler,
-		thumbnailHandler:       thumbnailHandler,
-		deleteVideoHandler:     deleteVideoHandler,
-		router:                 r,
+		cfg:                         cfg,
+		store:                       store,
+		filenames:                   filenames,
+		videoDuration:               videoDuration,
+		fileServer:                  fileServer,
+		downloadRequestService:      downloadRequestService,
+		videosHandler:               videosHandler,
+		pingHandler:                 pingHandler,
+		videoHandler:                videoHandler,
+		downloadHandler:             downloadHandler,
+		durationHandler:             durationHandler,
+		thumbnailHandler:            thumbnailHandler,
+		deleteVideoHandler:          deleteVideoHandler,
+		requestVideoDownloadHandler: requestVideoDownloadHandler,
+		router:                      r,
 	}
 }
 
@@ -78,36 +81,7 @@ func (s *GinServer) registerRoutes() {
 
 	s.router.POST("/delete-video", s.deleteVideoHandler.DeleteVideo)
 
-	s.router.POST("/request-video-download", func(c *gin.Context) {
-		var body struct {
-			URL string `json:"url" binding:"required"`
-		}
-		if err := c.ShouldBindJSON(&body); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "url is required"})
-			return
-		}
-
-		if !s.downloadRequestService.IsSupportedURL(body.URL) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Url must be from a supported service (YouTube, Twitch)"})
-			return
-		}
-
-		service, videoID, err := s.downloadRequestService.ExtractVideoID(body.URL)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-
-		filename := fmt.Sprintf("video.%s.%s.download", service, videoID)
-		path := filepath.Join(s.cfg.StreamsDir, filename)
-
-		if err := os.WriteFile(path, []byte(body.URL), 0644); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create download request"})
-			return
-		}
-
-		c.JSON(http.StatusCreated, gin.H{"id": videoID})
-	})
+	s.router.POST("/request-video-download", s.requestVideoDownloadHandler.RequestVideoDownload)
 
 	s.router.POST("/request-playlist-download", func(c *gin.Context) {
 		var body struct {

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -18,20 +18,38 @@ type GinServer struct {
 	fileServer             *GinSharableFileServer
 	downloadRequestService *DownloadRequestService
 	videosHandler          *VideosHandler
+	pingHandler            *PingHandler
 	router                 *gin.Engine
 }
 
-func NewGinServer(cfg *Config, store *VideoStore, filenames *Filenames, videoDuration *VideoDuration, fileServer *GinSharableFileServer, downloadRequestService *DownloadRequestService, videosHandler *VideosHandler) *GinServer {
+func NewGinServer(
+	cfg *Config,
+	store *VideoStore,
+	filenames *Filenames,
+	videoDuration *VideoDuration,
+	fileServer *GinSharableFileServer,
+	downloadRequestService *DownloadRequestService,
+	videosHandler *VideosHandler,
+	pingHandler *PingHandler,
+) *GinServer {
 	r := gin.Default()
-	return &GinServer{cfg: cfg, store: store, filenames: filenames, videoDuration: videoDuration, fileServer: fileServer, downloadRequestService: downloadRequestService, videosHandler: videosHandler, router: r}
+	return &GinServer{
+		cfg:                    cfg,
+		store:                  store,
+		filenames:              filenames,
+		videoDuration:          videoDuration,
+		fileServer:             fileServer,
+		downloadRequestService: downloadRequestService,
+		videosHandler:          videosHandler,
+		pingHandler:            pingHandler,
+		router:                 r,
+	}
 }
 
 func (s *GinServer) registerRoutes() {
 	s.router.Use(cors.Default())
 
-	s.router.GET("/ping", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "pong"})
-	})
+	s.router.GET("/ping", s.pingHandler.Ping)
 
 	s.router.GET("/videos", s.videosHandler.GetVideos)
 

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -20,6 +20,7 @@ type GinServer struct {
 	videosHandler          *VideosHandler
 	pingHandler            *PingHandler
 	videoHandler           *VideoHandler
+	downloadHandler        *DownloadHandler
 	router                 *gin.Engine
 }
 
@@ -33,6 +34,7 @@ func NewGinServer(
 	videosHandler *VideosHandler,
 	pingHandler *PingHandler,
 	videoHandler *VideoHandler,
+	downloadHandler *DownloadHandler,
 ) *GinServer {
 	r := gin.Default()
 	return &GinServer{
@@ -45,6 +47,7 @@ func NewGinServer(
 		videosHandler:          videosHandler,
 		pingHandler:            pingHandler,
 		videoHandler:           videoHandler,
+		downloadHandler:        downloadHandler,
 		router:                 r,
 	}
 }
@@ -58,25 +61,7 @@ func (s *GinServer) registerRoutes() {
 
 	s.router.GET("/video/:id", s.videoHandler.GetVideo)
 
-	s.router.GET("/download/:id", func(c *gin.Context) {
-		id := c.Param("id")
-		s.store.Mutex.RLock()
-		v, ok := s.store.VideosMap[id]
-		vv, versionOk := s.store.VideoVersionsMap[id]
-		s.store.Mutex.RUnlock()
-		if !ok && !versionOk {
-			c.Status(404)
-			return
-		}
-		var filename string
-		if versionOk {
-			filename = vv.Filename
-		} else {
-			filename = v.Filename
-		}
-		c.Header("Content-Disposition", `attachment; filename="`+filename+`"`)
-		s.fileServer.Serve(c, s.cfg.StreamsDir+"/"+filename, filename)
-	})
+	s.router.GET("/download/:id", s.downloadHandler.Download)
 
 	s.router.GET("/duration/:id", func(c *gin.Context) {
 		id := c.Param("id")

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -19,6 +19,7 @@ type GinServer struct {
 	downloadRequestService *DownloadRequestService
 	videosHandler          *VideosHandler
 	pingHandler            *PingHandler
+	videoHandler           *VideoHandler
 	router                 *gin.Engine
 }
 
@@ -31,6 +32,7 @@ func NewGinServer(
 	downloadRequestService *DownloadRequestService,
 	videosHandler *VideosHandler,
 	pingHandler *PingHandler,
+	videoHandler *VideoHandler,
 ) *GinServer {
 	r := gin.Default()
 	return &GinServer{
@@ -42,6 +44,7 @@ func NewGinServer(
 		downloadRequestService: downloadRequestService,
 		videosHandler:          videosHandler,
 		pingHandler:            pingHandler,
+		videoHandler:           videoHandler,
 		router:                 r,
 	}
 }
@@ -53,17 +56,7 @@ func (s *GinServer) registerRoutes() {
 
 	s.router.GET("/videos", s.videosHandler.GetVideos)
 
-	s.router.GET("/video/:id", func(c *gin.Context) {
-		id := c.Param("id")
-		s.store.Mutex.RLock()
-		v, ok := s.store.VideosMap[id]
-		s.store.Mutex.RUnlock()
-		if !ok {
-			c.Status(404)
-			return
-		}
-		s.fileServer.Serve(c, s.cfg.StreamsDir+"/"+v.Filename, v.Filename)
-	})
+	s.router.GET("/video/:id", s.videoHandler.GetVideo)
 
 	s.router.GET("/download/:id", func(c *gin.Context) {
 		id := c.Param("id")

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -17,12 +17,13 @@ type GinServer struct {
 	videoDuration          *VideoDuration
 	fileServer             *GinSharableFileServer
 	downloadRequestService *DownloadRequestService
+	videosHandler          *VideosHandler
 	router                 *gin.Engine
 }
 
-func NewGinServer(cfg *Config, store *VideoStore, filenames *Filenames, videoDuration *VideoDuration, fileServer *GinSharableFileServer, downloadRequestService *DownloadRequestService) *GinServer {
+func NewGinServer(cfg *Config, store *VideoStore, filenames *Filenames, videoDuration *VideoDuration, fileServer *GinSharableFileServer, downloadRequestService *DownloadRequestService, videosHandler *VideosHandler) *GinServer {
 	r := gin.Default()
-	return &GinServer{cfg: cfg, store: store, filenames: filenames, videoDuration: videoDuration, fileServer: fileServer, downloadRequestService: downloadRequestService, router: r}
+	return &GinServer{cfg: cfg, store: store, filenames: filenames, videoDuration: videoDuration, fileServer: fileServer, downloadRequestService: downloadRequestService, videosHandler: videosHandler, router: r}
 }
 
 func (s *GinServer) registerRoutes() {
@@ -32,22 +33,7 @@ func (s *GinServer) registerRoutes() {
 		c.JSON(200, gin.H{"message": "pong"})
 	})
 
-	s.router.GET("/videos", func(c *gin.Context) {
-		s.store.Mutex.RLock()
-		defer s.store.Mutex.RUnlock()
-		response := make([]VideoResponse, len(s.store.Videos))
-		for i, v := range s.store.Videos {
-			response[i] = VideoResponse{
-				ID:       v.ID,
-				Name:     v.Name,
-				Channel:  v.Channel,
-				Date:     v.Date,
-				Status:   v.Status,
-				Versions: v.Versions,
-			}
-		}
-		c.JSON(200, response)
-	})
+	s.router.GET("/videos", s.videosHandler.GetVideos)
 
 	s.router.GET("/video/:id", func(c *gin.Context) {
 		id := c.Param("id")

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -22,6 +22,7 @@ type GinServer struct {
 	videoHandler           *VideoHandler
 	downloadHandler        *DownloadHandler
 	durationHandler        *DurationHandler
+	thumbnailHandler       *ThumbnailHandler
 	router                 *gin.Engine
 }
 
@@ -37,6 +38,7 @@ func NewGinServer(
 	videoHandler *VideoHandler,
 	downloadHandler *DownloadHandler,
 	durationHandler *DurationHandler,
+	thumbnailHandler *ThumbnailHandler,
 ) *GinServer {
 	r := gin.Default()
 	return &GinServer{
@@ -51,6 +53,7 @@ func NewGinServer(
 		videoHandler:           videoHandler,
 		downloadHandler:        downloadHandler,
 		durationHandler:        durationHandler,
+		thumbnailHandler:       thumbnailHandler,
 		router:                 r,
 	}
 }
@@ -68,25 +71,7 @@ func (s *GinServer) registerRoutes() {
 
 	s.router.GET("/duration/:id", s.durationHandler.GetDuration)
 
-	s.router.GET("/thumbnail/:id", func(c *gin.Context) {
-		id := c.Param("id")
-		s.store.Mutex.RLock()
-		v, ok := s.store.VideosMap[id]
-		s.store.Mutex.RUnlock()
-		if !ok {
-			c.Status(404)
-			return
-		}
-		thumbPath := filepath.Join(s.cfg.StreamsDir, s.filenames.Thumbnail(v.Filename))
-		if _, err := os.Stat(thumbPath); err != nil {
-			c.Status(404)
-			return
-		}
-		if v.Status == "Ready" {
-			c.Header("Cache-Control", "public, max-age=18000")
-		}
-		c.File(thumbPath)
-	})
+	s.router.GET("/thumbnail/:id", s.thumbnailHandler.GetThumbnail)
 
 	s.router.POST("/delete-video", func(c *gin.Context) {
 		var body struct {

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -21,6 +21,7 @@ type GinServer struct {
 	pingHandler            *PingHandler
 	videoHandler           *VideoHandler
 	downloadHandler        *DownloadHandler
+	durationHandler        *DurationHandler
 	router                 *gin.Engine
 }
 
@@ -35,6 +36,7 @@ func NewGinServer(
 	pingHandler *PingHandler,
 	videoHandler *VideoHandler,
 	downloadHandler *DownloadHandler,
+	durationHandler *DurationHandler,
 ) *GinServer {
 	r := gin.Default()
 	return &GinServer{
@@ -48,6 +50,7 @@ func NewGinServer(
 		pingHandler:            pingHandler,
 		videoHandler:           videoHandler,
 		downloadHandler:        downloadHandler,
+		durationHandler:        durationHandler,
 		router:                 r,
 	}
 }
@@ -63,25 +66,7 @@ func (s *GinServer) registerRoutes() {
 
 	s.router.GET("/download/:id", s.downloadHandler.Download)
 
-	s.router.GET("/duration/:id", func(c *gin.Context) {
-		id := c.Param("id")
-		s.store.Mutex.RLock()
-		v, ok := s.store.VideosMap[id]
-		s.store.Mutex.RUnlock()
-		if !ok {
-			c.Status(404)
-			return
-		}
-		duration, err := s.videoDuration.Get(s.cfg.StreamsDir + "/" + v.Filename)
-		if err != nil {
-			c.Status(500)
-			return
-		}
-		if v.Status == "Ready" {
-			c.Header("Cache-Control", "public, max-age=18000")
-		}
-		c.JSON(200, gin.H{"duration": duration})
-	})
+	s.router.GET("/duration/:id", s.durationHandler.GetDuration)
 
 	s.router.GET("/thumbnail/:id", func(c *gin.Context) {
 		id := c.Param("id")

--- a/backend/gin_server.go
+++ b/backend/gin_server.go
@@ -1,11 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
-	"os"
-	"path/filepath"
-
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
@@ -24,8 +19,9 @@ type GinServer struct {
 	durationHandler        *DurationHandler
 	thumbnailHandler       *ThumbnailHandler
 	deleteVideoHandler              *DeleteVideoHandler
-	requestVideoDownloadHandler     *RequestVideoDownloadHandler
-	router                          *gin.Engine
+	requestVideoDownloadHandler    *RequestVideoDownloadHandler
+	requestPlaylistDownloadHandler *RequestPlaylistDownloadHandler
+	router                         *gin.Engine
 }
 
 func NewGinServer(
@@ -43,24 +39,26 @@ func NewGinServer(
 	thumbnailHandler *ThumbnailHandler,
 	deleteVideoHandler *DeleteVideoHandler,
 	requestVideoDownloadHandler *RequestVideoDownloadHandler,
+	requestPlaylistDownloadHandler *RequestPlaylistDownloadHandler,
 ) *GinServer {
 	r := gin.Default()
 	return &GinServer{
-		cfg:                         cfg,
-		store:                       store,
-		filenames:                   filenames,
-		videoDuration:               videoDuration,
-		fileServer:                  fileServer,
-		downloadRequestService:      downloadRequestService,
-		videosHandler:               videosHandler,
-		pingHandler:                 pingHandler,
-		videoHandler:                videoHandler,
-		downloadHandler:             downloadHandler,
-		durationHandler:             durationHandler,
-		thumbnailHandler:            thumbnailHandler,
-		deleteVideoHandler:          deleteVideoHandler,
-		requestVideoDownloadHandler: requestVideoDownloadHandler,
-		router:                      r,
+		cfg:                            cfg,
+		store:                          store,
+		filenames:                      filenames,
+		videoDuration:                  videoDuration,
+		fileServer:                     fileServer,
+		downloadRequestService:         downloadRequestService,
+		videosHandler:                  videosHandler,
+		pingHandler:                    pingHandler,
+		videoHandler:                   videoHandler,
+		downloadHandler:                downloadHandler,
+		durationHandler:                durationHandler,
+		thumbnailHandler:               thumbnailHandler,
+		deleteVideoHandler:             deleteVideoHandler,
+		requestVideoDownloadHandler:    requestVideoDownloadHandler,
+		requestPlaylistDownloadHandler: requestPlaylistDownloadHandler,
+		router:                         r,
 	}
 }
 
@@ -83,29 +81,5 @@ func (s *GinServer) registerRoutes() {
 
 	s.router.POST("/request-video-download", s.requestVideoDownloadHandler.RequestVideoDownload)
 
-	s.router.POST("/request-playlist-download", func(c *gin.Context) {
-		var body struct {
-			URL string `json:"url" binding:"required"`
-		}
-		if err := c.ShouldBindJSON(&body); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "url is required"})
-			return
-		}
-
-		service, playlistID, err := s.downloadRequestService.ExtractPlaylistID(body.URL)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-
-		filename := fmt.Sprintf("playlist.%s.%s.download", service, playlistID)
-		path := filepath.Join(s.cfg.StreamsDir, filename)
-
-		if err := os.WriteFile(path, []byte(body.URL), 0644); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create download request"})
-			return
-		}
-
-		c.JSON(http.StatusCreated, gin.H{"id": playlistID})
-	})
+	s.router.POST("/request-playlist-download", s.requestPlaylistDownloadHandler.RequestPlaylistDownload)
 }

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -45,6 +45,7 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewDurationHandler),
 		fx.Provide(NewThumbnailHandler),
 		fx.Provide(NewDeleteVideoHandler),
+		fx.Provide(NewRequestVideoDownloadHandler),
 		fx.Provide(NewGinServer),
 	)
 }

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -38,6 +38,7 @@ func CoreProviders() fx.Option {
 		}),
 		fx.Provide(NewLowerQualityRecoderWorker),
 		fx.Provide(NewDownloadRequestService),
+		fx.Provide(NewVideosHandler),
 		fx.Provide(NewGinServer),
 	)
 }

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -40,6 +40,7 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewDownloadRequestService),
 		fx.Provide(NewVideosHandler),
 		fx.Provide(NewPingHandler),
+		fx.Provide(NewVideoHandler),
 		fx.Provide(NewGinServer),
 	)
 }

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -42,6 +42,7 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewPingHandler),
 		fx.Provide(NewVideoHandler),
 		fx.Provide(NewDownloadHandler),
+		fx.Provide(NewDurationHandler),
 		fx.Provide(NewGinServer),
 	)
 }

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -41,6 +41,7 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewVideosHandler),
 		fx.Provide(NewPingHandler),
 		fx.Provide(NewVideoHandler),
+		fx.Provide(NewDownloadHandler),
 		fx.Provide(NewGinServer),
 	)
 }

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -44,6 +44,7 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewDownloadHandler),
 		fx.Provide(NewDurationHandler),
 		fx.Provide(NewThumbnailHandler),
+		fx.Provide(NewDeleteVideoHandler),
 		fx.Provide(NewGinServer),
 	)
 }

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -46,6 +46,7 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewThumbnailHandler),
 		fx.Provide(NewDeleteVideoHandler),
 		fx.Provide(NewRequestVideoDownloadHandler),
+		fx.Provide(NewRequestPlaylistDownloadHandler),
 		fx.Provide(NewGinServer),
 	)
 }

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -39,6 +39,7 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewLowerQualityRecoderWorker),
 		fx.Provide(NewDownloadRequestService),
 		fx.Provide(NewVideosHandler),
+		fx.Provide(NewPingHandler),
 		fx.Provide(NewGinServer),
 	)
 }

--- a/backend/ioc.go
+++ b/backend/ioc.go
@@ -43,6 +43,7 @@ func CoreProviders() fx.Option {
 		fx.Provide(NewVideoHandler),
 		fx.Provide(NewDownloadHandler),
 		fx.Provide(NewDurationHandler),
+		fx.Provide(NewThumbnailHandler),
 		fx.Provide(NewGinServer),
 	)
 }

--- a/backend/ping_handler.go
+++ b/backend/ping_handler.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+type PingHandler struct{}
+
+func NewPingHandler() *PingHandler {
+	return &PingHandler{}
+}
+
+func (h *PingHandler) Ping(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "pong"})
+}

--- a/backend/request_playlist_download_handler.go
+++ b/backend/request_playlist_download_handler.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+)
+
+type RequestPlaylistDownloadHandler struct {
+	cfg                    *Config
+	downloadRequestService *DownloadRequestService
+}
+
+func NewRequestPlaylistDownloadHandler(cfg *Config, downloadRequestService *DownloadRequestService) *RequestPlaylistDownloadHandler {
+	return &RequestPlaylistDownloadHandler{cfg: cfg, downloadRequestService: downloadRequestService}
+}
+
+func (h *RequestPlaylistDownloadHandler) RequestPlaylistDownload(c *gin.Context) {
+	var body struct {
+		URL string `json:"url" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "url is required"})
+		return
+	}
+
+	service, playlistID, err := h.downloadRequestService.ExtractPlaylistID(body.URL)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	filename := fmt.Sprintf("playlist.%s.%s.download", service, playlistID)
+	path := filepath.Join(h.cfg.StreamsDir, filename)
+
+	if err := os.WriteFile(path, []byte(body.URL), 0644); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create download request"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"id": playlistID})
+}

--- a/backend/request_video_download_handler.go
+++ b/backend/request_video_download_handler.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+)
+
+type RequestVideoDownloadHandler struct {
+	cfg                    *Config
+	downloadRequestService *DownloadRequestService
+}
+
+func NewRequestVideoDownloadHandler(cfg *Config, downloadRequestService *DownloadRequestService) *RequestVideoDownloadHandler {
+	return &RequestVideoDownloadHandler{cfg: cfg, downloadRequestService: downloadRequestService}
+}
+
+func (h *RequestVideoDownloadHandler) RequestVideoDownload(c *gin.Context) {
+	var body struct {
+		URL string `json:"url" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "url is required"})
+		return
+	}
+
+	if !h.downloadRequestService.IsSupportedURL(body.URL) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Url must be from a supported service (YouTube, Twitch)"})
+		return
+	}
+
+	service, videoID, err := h.downloadRequestService.ExtractVideoID(body.URL)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	filename := fmt.Sprintf("video.%s.%s.download", service, videoID)
+	path := filepath.Join(h.cfg.StreamsDir, filename)
+
+	if err := os.WriteFile(path, []byte(body.URL), 0644); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create download request"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"id": videoID})
+}

--- a/backend/thumbnail_handler.go
+++ b/backend/thumbnail_handler.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+)
+
+type ThumbnailHandler struct {
+	cfg       *Config
+	store     *VideoStore
+	filenames *Filenames
+}
+
+func NewThumbnailHandler(cfg *Config, store *VideoStore, filenames *Filenames) *ThumbnailHandler {
+	return &ThumbnailHandler{cfg: cfg, store: store, filenames: filenames}
+}
+
+func (h *ThumbnailHandler) GetThumbnail(c *gin.Context) {
+	id := c.Param("id")
+	h.store.Mutex.RLock()
+	v, ok := h.store.VideosMap[id]
+	h.store.Mutex.RUnlock()
+	if !ok {
+		c.Status(404)
+		return
+	}
+	thumbPath := filepath.Join(h.cfg.StreamsDir, h.filenames.Thumbnail(v.Filename))
+	if _, err := os.Stat(thumbPath); err != nil {
+		c.Status(404)
+		return
+	}
+	if v.Status == "Ready" {
+		c.Header("Cache-Control", "public, max-age=18000")
+	}
+	c.File(thumbPath)
+}

--- a/backend/video_handler.go
+++ b/backend/video_handler.go
@@ -1,0 +1,25 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+type VideoHandler struct {
+	cfg        *Config
+	store      *VideoStore
+	fileServer *GinSharableFileServer
+}
+
+func NewVideoHandler(cfg *Config, store *VideoStore, fileServer *GinSharableFileServer) *VideoHandler {
+	return &VideoHandler{cfg: cfg, store: store, fileServer: fileServer}
+}
+
+func (h *VideoHandler) GetVideo(c *gin.Context) {
+	id := c.Param("id")
+	h.store.Mutex.RLock()
+	v, ok := h.store.VideosMap[id]
+	h.store.Mutex.RUnlock()
+	if !ok {
+		c.Status(404)
+		return
+	}
+	h.fileServer.Serve(c, h.cfg.StreamsDir+"/"+v.Filename, v.Filename)
+}

--- a/backend/videos_handler.go
+++ b/backend/videos_handler.go
@@ -1,0 +1,28 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+type VideosHandler struct {
+	store *VideoStore
+}
+
+func NewVideosHandler(store *VideoStore) *VideosHandler {
+	return &VideosHandler{store: store}
+}
+
+func (h *VideosHandler) GetVideos(c *gin.Context) {
+	h.store.Mutex.RLock()
+	defer h.store.Mutex.RUnlock()
+	response := make([]VideoResponse, len(h.store.Videos))
+	for i, v := range h.store.Videos {
+		response[i] = VideoResponse{
+			ID:       v.ID,
+			Name:     v.Name,
+			Channel:  v.Channel,
+			Date:     v.Date,
+			Status:   v.Status,
+			Versions: v.Versions,
+		}
+	}
+	c.JSON(200, response)
+}


### PR DESCRIPTION
Closes #72

## Summary
- Extracted each Gin route handler from `GinServer` into its own dedicated struct/file
- Handlers extracted: `VideosHandler`, `PingHandler`, `VideoHandler`, `DownloadHandler`, `DurationHandler`, `ThumbnailHandler`, `DeleteVideoHandler`, `RequestVideoDownloadHandler`, `RequestPlaylistDownloadHandler`

## Test plan
- [ ] All existing API endpoints respond correctly
- [ ] No regressions in video listing, playback, download, thumbnail, and delete flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)