### PR TITLE
Unpause video when seeking with arrow keys while paused

### DIFF
--- a/frontend/src/hooks/frontend/useVideoKeyboard.js
+++ b/frontend/src/hooks/frontend/useVideoKeyboard.js
@@ -8,6 +8,7 @@ export function useVideoKeyboard(videoRef) {
             if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
                 e.preventDefault()
                 videoRef.current.currentTime += e.key === 'ArrowRight' ? 10 : -10
+                if (videoRef.current.paused) videoRef.current.play()
             }
         }
         document.addEventListener('keydown', handleKeyDown, { capture: true })


### PR DESCRIPTION
Closes #74

## Summary
- After seeking ±10s with arrow keys, call `play()` if the video was paused

## Test plan
- [ ] Pause video, press left/right arrow — video seeks and resumes playing
- [ ] Video already playing — arrow keys seek without interruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)