### PR TITLE
Limit ffmpeg logs and stats to 1 per minute in Go backend

### DIFF
--- a/backend/480p_video_recoder.go
+++ b/backend/480p_video_recoder.go
@@ -28,6 +28,7 @@ func (r *Video480pRecoder) Recode(inputPath, outputPath string) error {
 			"c:a":       "copy",
 			"movflags":  "+faststart",
 		}).
+		GlobalArgs("-loglevel", "warning", "-stats", "-stats_period", "60").
 		Compile()
 
 	cmd.Stderr = os.Stderr

--- a/backend/720p_video_recoder.go
+++ b/backend/720p_video_recoder.go
@@ -28,6 +28,7 @@ func (r *Video720pRecoder) Recode(inputPath, outputPath string) error {
 			"c:a":       "copy",
 			"movflags":  "+faststart",
 		}).
+		GlobalArgs("-loglevel", "warning", "-stats", "-stats_period", "60").
 		Compile()
 
 	cmd.Stderr = os.Stderr

--- a/backend/ios_video_recoder.go
+++ b/backend/ios_video_recoder.go
@@ -33,6 +33,7 @@ func (r *IOSVideoRecoder) Recode(videoPath string, bitrate int64) error {
 			"c:a":       "copy",
 			"movflags":  "+faststart",
 		}).
+		GlobalArgs("-loglevel", "warning", "-stats", "-stats_period", "60").
 		Compile()
 
 	cmd.Stderr = os.Stderr

--- a/backend/video_splitter.go
+++ b/backend/video_splitter.go
@@ -27,6 +27,7 @@ func (vs *VideoSplitter) Split(videoPath string, splitDuration float64) error {
 			"reset_timestamps":     1,
 			"segment_start_number": 1,
 		}).
+		GlobalArgs("-loglevel", "warning", "-stats", "-stats_period", "60").
 		Compile()
 
 	var stderr bytes.Buffer


### PR DESCRIPTION
Closes #69

## Summary
- Added `-loglevel warning -stats -stats_period 60` global args to all long-running ffmpeg commands: 480p recoder, 720p recoder, iOS recoder, video splitter
- Matches the same approach already used in the Python twitch downloader

## Test plan
- [ ] Recode a video to 480p/720p — only warnings and 1-per-minute stats lines appear
- [ ] iOS recode — same
- [ ] Video split — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)