### PR TITLE
Delete orphaned 480p/720p recode files when main video is deleted

### DIFF
--- a/backend/cleanup_worker.go
+++ b/backend/cleanup_worker.go
@@ -39,6 +39,9 @@ func (cw *CleanupWorker) Start() {
 					if b, ok := strings.CutSuffix(name, "."+quality+".mp4"); ok {
 						base = b
 						break
+					} else if b, ok := strings.CutSuffix(name, "."+quality+".temp.mp4"); ok {
+						base = b
+						break
 					}
 				}
 				if base == "" {

--- a/backend/cleanup_worker.go
+++ b/backend/cleanup_worker.go
@@ -9,11 +9,12 @@ import (
 )
 
 type CleanupWorker struct {
-	cfg *Config
+	cfg       *Config
+	filenames *Filenames
 }
 
-func NewCleanupWorker(cfg *Config) *CleanupWorker {
-	return &CleanupWorker{cfg: cfg}
+func NewCleanupWorker(cfg *Config, filenames *Filenames) *CleanupWorker {
+	return &CleanupWorker{cfg: cfg, filenames: filenames}
 }
 
 func (cw *CleanupWorker) Start() {
@@ -34,7 +35,15 @@ func (cw *CleanupWorker) Start() {
 			} else if b, ok := strings.CutSuffix(name, ".ios_fix.txt"); ok {
 				base = b
 			} else {
-				continue
+				for _, quality := range cw.cfg.RecodeQualities {
+					if b, ok := strings.CutSuffix(name, "."+quality+".mp4"); ok {
+						base = b
+						break
+					}
+				}
+				if base == "" {
+					continue
+				}
 			}
 
 			exists := false

--- a/backend/fix_ios_worker.go
+++ b/backend/fix_ios_worker.go
@@ -53,6 +53,7 @@ func (fw *FixIOSWorker) processNext() bool {
 			continue
 		}
 		if !validation.NeedsIOSFix {
+			log.Println("ios fix not needed for", v.Filename)
 			if err := os.WriteFile(fixPath, []byte("ok"), 0644); err != nil {
 				log.Println("error writing ios fix marker for", v.Filename, ":", err)
 			}


### PR DESCRIPTION
Closes #57

## Summary
- `CleanupWorker` now also detects and removes orphaned recode files (e.g. `video.480p.mp4`, `video.720p.mp4`) when the source video no longer exists
- Qualities are read from `cfg.RecodeQualities` so no hardcoding — picks up any future quality additions automatically
- Injected `*Filenames` into `CleanupWorker` (fx resolves it automatically)

## Test plan
- [ ] Delete a main video that has 480p/720p recodes — both recode files are removed within 1 minute
- [ ] Delete a main video with no recodes — no errors
- [ ] Existing orphan cleanup (thumbnails, duration files, ios_fix) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)