### PR TITLE
Navigate to correct part on playlist click; save time on video end

### DIFF
--- a/frontend/src/components/frontend/SearchBar/SearchBar.jsx
+++ b/frontend/src/components/frontend/SearchBar/SearchBar.jsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Search, X } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import Fuse from 'fuse.js'
+import { videoLink } from '@/lib/video'
 
 export default function SearchBar({ videos = [] }) {
     const [query, setQuery] = useState(() => localStorage.getItem('searchQuery') ?? '')
@@ -47,7 +48,7 @@ export default function SearchBar({ videos = [] }) {
                             ? results.map(video => (
                                 <li
                                     key={video.id}
-                                    onMouseDown={() => { updateQuery(''); navigate(`/watch/${video.id}`) }}
+                                    onMouseDown={() => { updateQuery(''); navigate(videoLink(video)) }}
                                     className="px-4 py-2 text-sm text-gray-900 hover:bg-gray-100 cursor-pointer flex items-center gap-2 min-w-0"
                                     title={video.name}
                                 >

--- a/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
@@ -2,17 +2,12 @@ import { Link } from 'react-router-dom'
 import VideoListItemMenu from './VideoListItemMenu'
 import VideoListItemThumbnail from './VideoListItemThumbnail'
 import VideoListItemInfo from './VideoListItemInfo'
-
+import { videoLink, isFullyWatched } from '@/lib/video'
 
 function getTargetLink(video, playlistVideos) {
-    if (!playlistVideos) {
-        return video.savedTime ? `/watch/${video.id}?t=${video.savedTime}` : `/watch/${video.id}`
-    }
-    const target = playlistVideos.find(v => {
-        const saved = parseFloat(v.savedTime) || 0
-        return !v.duration || saved < v.duration - 5
-    }) ?? playlistVideos[playlistVideos.length - 1]
-    return target.savedTime ? `/watch/${target.id}?t=${target.savedTime}` : `/watch/${target.id}`
+    if (!playlistVideos) return videoLink(video)
+    const target = playlistVideos.find(v => !isFullyWatched(v)) ?? playlistVideos[playlistVideos.length - 1]
+    return videoLink(target)
 }
 
 export default function VideoListItem({ video, isSelected, videoCountVisible, onWatchedReset, onWatchedMark, onDelete, playlistVideos }) {

--- a/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom'
-import { formatDistanceToNow, format } from 'date-fns'
 import VideoListItemMenu from './VideoListItemMenu'
+import VideoListItemThumbnail from './VideoListItemThumbnail'
+import VideoListItemInfo from './VideoListItemInfo'
 
-const API_URL = import.meta.env.VITE_API_URL
 
 export default function VideoListItem({ video, isSelected, videoCountVisible, onWatchedReset, onWatchedMark, onDelete, playlistVideos }) {
 
@@ -21,37 +21,12 @@ export default function VideoListItem({ video, isSelected, videoCountVisible, on
                 className="flex gap-2 min-w-0 flex-1"
             >
                 <div className="flex flex-row gap-2 min-w-0 overflow-hidden">
-                    <div className="relative flex-shrink-0">
-                        <img
-                            src={`${API_URL}/thumbnail/${video.id}`}
-                            className="w-36 h-20 object-cover rounded bg-gray-300"
-                        />
-                        {!!progressSavedTime && !!progressDuration && (
-                            <div className="absolute bottom-0 left-0 right-0 h-1 bg-white/30 rounded-bl">
-                                <div
-                                    className={`h-full bg-red-500 rounded-bl${progressSavedTime >= progressDuration ? ' rounded-br' : ''}`}
-                                    style={{ width: `${Math.min(progressSavedTime / progressDuration * 100, 100)}%` }}
-                                />
-                            </div>
-                        )}
-                        {progressDuration != null && (
-                            <span className="absolute bottom-2 right-1 bg-black/60 text-white text-xs px-1 rounded">
-                                {new Date(progressDuration * 1000).toISOString().substring(progressDuration >= 3600 ? 11 : 14, 19)}
-                            </span>
-                        )}
-                    </div>
-                    <div className="flex flex-col justify-start min-w-0">
-                        <p className="text-sm font-medium text-gray-900 line-clamp-2">
-                            {video.name}
-                        </p>
-                        <p className="text-xs text-gray-500 mt-1 truncate" title={video.date ? format(new Date(video.date), 'PPpp') : undefined}>
-                            {[video.channel, video.date ? formatDistanceToNow(new Date(video.date), { addSuffix: true }) : null].filter(Boolean).join(' · ')}
-                        </p>
-                        {video.status !== 'Ready'
-                            ? <p className="text-xs text-gray-400 mt-1">{video.status}</p>
-                            : videoCountVisible && video.videoCount > 1 && <p className="text-xs text-gray-400 mt-1">{video.videoCount} videos</p>
-                        }
-                    </div>
+                    <VideoListItemThumbnail
+                        videoId={video.id}
+                        progressSavedTime={progressSavedTime}
+                        progressDuration={progressDuration}
+                    />
+                    <VideoListItemInfo video={video} videoCountVisible={videoCountVisible} />
                 </div>
             </Link>
 

--- a/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
@@ -4,6 +4,17 @@ import VideoListItemThumbnail from './VideoListItemThumbnail'
 import VideoListItemInfo from './VideoListItemInfo'
 
 
+function getTargetLink(video, playlistVideos) {
+    if (!playlistVideos) {
+        return video.savedTime ? `/watch/${video.id}?t=${video.savedTime}` : `/watch/${video.id}`
+    }
+    const target = playlistVideos.find(v => {
+        const saved = parseFloat(v.savedTime) || 0
+        return !v.duration || saved < v.duration - 5
+    }) ?? playlistVideos[playlistVideos.length - 1]
+    return target.savedTime ? `/watch/${target.id}?t=${target.savedTime}` : `/watch/${target.id}`
+}
+
 export default function VideoListItem({ video, isSelected, videoCountVisible, onWatchedReset, onWatchedMark, onDelete, playlistVideos }) {
 
     const progressSavedTime = playlistVideos
@@ -16,7 +27,7 @@ export default function VideoListItem({ video, isSelected, videoCountVisible, on
     return (
         <div className={`flex items-center p-2 hover:bg-gray-100 ${isSelected ? 'bg-gray-200' : ''}`}>
             <Link
-                to={video.savedTime ? `/watch/${video.id}?t=${video.savedTime}` : `/watch/${video.id}`}
+                to={getTargetLink(video, playlistVideos)}
                 title={video.name}
                 className="flex gap-2 min-w-0 flex-1"
             >

--- a/frontend/src/components/frontend/VideoListItem/VideoListItemInfo.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItemInfo.jsx
@@ -1,0 +1,18 @@
+import { formatDistanceToNow, format } from 'date-fns'
+
+export default function VideoListItemInfo({ video, videoCountVisible }) {
+    return (
+        <div className="flex flex-col justify-start min-w-0">
+            <p className="text-sm font-medium text-gray-900 line-clamp-2">
+                {video.name}
+            </p>
+            <p className="text-xs text-gray-500 mt-1 truncate" title={video.date ? format(new Date(video.date), 'PPpp') : undefined}>
+                {[video.channel, video.date ? formatDistanceToNow(new Date(video.date), { addSuffix: true }) : null].filter(Boolean).join(' · ')}
+            </p>
+            {video.status !== 'Ready'
+                ? <p className="text-xs text-gray-400 mt-1">{video.status}</p>
+                : videoCountVisible && video.videoCount > 1 && <p className="text-xs text-gray-400 mt-1">{video.videoCount} videos</p>
+            }
+        </div>
+    )
+}

--- a/frontend/src/components/frontend/VideoListItem/VideoListItemThumbnail.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItemThumbnail.jsx
@@ -1,0 +1,25 @@
+const API_URL = import.meta.env.VITE_API_URL
+
+export default function VideoListItemThumbnail({ videoId, progressSavedTime, progressDuration }) {
+    return (
+        <div className="relative flex-shrink-0">
+            <img
+                src={`${API_URL}/thumbnail/${videoId}`}
+                className="w-36 h-20 object-cover rounded bg-gray-300"
+            />
+            {!!progressSavedTime && !!progressDuration && (
+                <div className="absolute bottom-0 left-0 right-0 h-1 bg-white/30 rounded-bl">
+                    <div
+                        className={`h-full bg-red-500 rounded-bl${progressSavedTime >= progressDuration ? ' rounded-br' : ''}`}
+                        style={{ width: `${Math.min(progressSavedTime / progressDuration * 100, 100)}%` }}
+                    />
+                </div>
+            )}
+            {progressDuration != null && (
+                <span className="absolute bottom-2 right-1 bg-black/60 text-white text-xs px-1 rounded">
+                    {new Date(progressDuration * 1000).toISOString().substring(progressDuration >= 3600 ? 11 : 14, 19)}
+                </span>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/components/frontend/VideoPlayer/VideoPlayer.jsx
+++ b/frontend/src/components/frontend/VideoPlayer/VideoPlayer.jsx
@@ -30,6 +30,7 @@ const VideoPlayer = forwardRef(function VideoPlayer({ video, onVideoUpdated }, r
                 if (t === parseInt(searchParams.get('t'))) return
                 saveWatchedTime(t)
             }}
+            onEnded={e => saveWatchedTime(Math.round(e.target.currentTime))}
             onLoadedMetadata={e => {
                 const t = searchParams.get('t')
                 if (t) e.target.currentTime = parseFloat(t)

--- a/frontend/src/components/frontend/VideoPlayer/VideoPlayer.jsx
+++ b/frontend/src/components/frontend/VideoPlayer/VideoPlayer.jsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { VIDEO_SAVE_INTERVAL } from '@/lib/video'
 
 const VideoPlayer = forwardRef(function VideoPlayer({ video, onVideoUpdated }, ref) {
     const [searchParams, setSearchParams] = useSearchParams()
@@ -21,7 +22,7 @@ const VideoPlayer = forwardRef(function VideoPlayer({ video, onVideoUpdated }, r
             playsInline
             onTimeUpdate={e => {
                 const t = Math.round(e.target.currentTime)
-                if (t % 5 !== 0) return
+                if (t % VIDEO_SAVE_INTERVAL !== 0) return
                 if (t === parseInt(searchParams.get('t'))) return
                 saveWatchedTime(t)
             }}

--- a/frontend/src/lib/video.js
+++ b/frontend/src/lib/video.js
@@ -1,0 +1,10 @@
+export const VIDEO_SAVE_INTERVAL = 5
+
+export function videoLink(video) {
+    return video.savedTime ? `/watch/${video.id}?t=${video.savedTime}` : `/watch/${video.id}`
+}
+
+export function isFullyWatched(video) {
+    const saved = parseFloat(video.savedTime) || 0
+    return !!video.duration && saved >= video.duration - VIDEO_SAVE_INTERVAL
+}


### PR DESCRIPTION
Closes #45

## Summary
- Clicking a playlist item in the sidebar now navigates to the first unwatched part (`savedTime < duration - 5s`); falls back to the last part if all are fully watched
- `VideoPlayer` now saves watched time `onEnded`, fixing the case where `duration % 5 !== 0` would skip saving the final position
- Extracted `VIDEO_SAVE_INTERVAL`, `videoLink`, and `isFullyWatched` into `src/lib/video.js` to share the 5s constant across `VideoListItem` and `VideoPlayer`
- `SearchBar` now uses `videoLink` to resume from saved position when navigating to a search result

## Test plan
- [ ] Playlist with 3 parts: parts 1+2 fully watched, part 3 at 20% — clicking the playlist item navigates to part 3
- [ ] All parts fully watched — clicking navigates to the last part
- [ ] Video ending at non-multiple-of-5 seconds saves the correct end time
- [ ] Searching and clicking a video resumes from saved position

🤖 Generated with [Claude Code](https://claude.com/claude-code)