### PR TITLE
Play 480p or 720p video (#46)

### DIFF
--- a/backend/video_handler.go
+++ b/backend/video_handler.go
@@ -16,10 +16,16 @@ func (h *VideoHandler) GetVideo(c *gin.Context) {
 	id := c.Param("id")
 	h.store.Mutex.RLock()
 	v, ok := h.store.VideosMap[id]
-	h.store.Mutex.RUnlock()
 	if !ok {
-		c.Status(404)
+		vv, vok := h.store.VideoVersionsMap[id]
+		h.store.Mutex.RUnlock()
+		if !vok {
+			c.Status(404)
+			return
+		}
+		h.fileServer.Serve(c, h.cfg.StreamsDir+"/"+vv.Filename, vv.Filename)
 		return
 	}
+	h.store.Mutex.RUnlock()
 	h.fileServer.Serve(c, h.cfg.StreamsDir+"/"+v.Filename, v.Filename)
 }

--- a/frontend/src/components/frontend/PlaylistPanel/PlaylistPanel.jsx
+++ b/frontend/src/components/frontend/PlaylistPanel/PlaylistPanel.jsx
@@ -1,6 +1,6 @@
 import VideoListItem from '@/components/frontend/VideoListItem/VideoListItem'
 
-export default function PlaylistPanel({ currentPlaylist, selectedVideoId, onWatchedReset, onWatchedMark, onDelete }) {
+export default function PlaylistPanel({ currentPlaylist, selectedVideoId, currentQuality, onWatchedReset, onWatchedMark, onDelete }) {
     return (
         <div className="border border-gray-400 rounded-lg m-2 overflow-hidden">
             <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">Playlist</p>
@@ -9,6 +9,7 @@ export default function PlaylistPanel({ currentPlaylist, selectedVideoId, onWatc
                     key={video.id}
                     video={video}
                     isSelected={selectedVideoId === video.id}
+                    currentQuality={currentQuality}
                     onWatchedReset={onWatchedReset}
                     onWatchedMark={onWatchedMark}
                     onDelete={onDelete}

--- a/frontend/src/components/frontend/VideoInfo/VideoInfo.jsx
+++ b/frontend/src/components/frontend/VideoInfo/VideoInfo.jsx
@@ -1,5 +1,5 @@
 import { formatDistanceToNow, format } from 'date-fns'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import { Badge } from '@/components/ui/badge'
 
 export default function VideoInfo({ video }) {
@@ -19,7 +19,7 @@ export default function VideoInfo({ video }) {
             {video.versions?.length > 0 && (
                 <div className="flex gap-2 mt-2">
                     <Badge
-                        render={<button />}
+                        render={<Link to={video.savedTime ? `/watch/${video.id}?t=${video.savedTime}` : `/watch/${video.id}`} />}
                         variant={id === video.id ? 'default' : 'outline'}
                     >
                         original
@@ -27,7 +27,7 @@ export default function VideoInfo({ video }) {
                     {video.versions.map(v => (
                         <Badge
                             key={v.id}
-                            render={<button />}
+                            render={<Link to={video.savedTime ? `/watch/${v.id}?t=${video.savedTime}` : `/watch/${v.id}`} />}
                             variant={id === v.id ? 'default' : 'outline'}
                         >
                             {v.quality}

--- a/frontend/src/components/frontend/VideoInfo/VideoInfo.jsx
+++ b/frontend/src/components/frontend/VideoInfo/VideoInfo.jsx
@@ -1,6 +1,10 @@
 import { formatDistanceToNow, format } from 'date-fns'
+import { useParams } from 'react-router-dom'
+import { Badge } from '@/components/ui/badge'
 
 export default function VideoInfo({ video }) {
+    const { id } = useParams()
+
     return (
         <>
             <p className="font-semibold text-lg">{video.name}</p>
@@ -11,6 +15,25 @@ export default function VideoInfo({ video }) {
                 <p className="text-sm text-gray-500 mt-1" title={format(new Date(video.date), 'PPpp')}>
                     {formatDistanceToNow(new Date(video.date), { addSuffix: true })}
                 </p>
+            )}
+            {video.versions?.length > 0 && (
+                <div className="flex gap-2 mt-2">
+                    <Badge
+                        render={<button />}
+                        variant={id === video.id ? 'default' : 'outline'}
+                    >
+                        original
+                    </Badge>
+                    {video.versions.map(v => (
+                        <Badge
+                            key={v.id}
+                            render={<button />}
+                            variant={id === v.id ? 'default' : 'outline'}
+                        >
+                            {v.quality}
+                        </Badge>
+                    ))}
+                </div>
             )}
         </>
     )

--- a/frontend/src/components/frontend/VideoList/VideoList.jsx
+++ b/frontend/src/components/frontend/VideoList/VideoList.jsx
@@ -3,7 +3,7 @@ import VideoListItem from '@/components/frontend/VideoListItem/VideoListItem'
 export default function VideoList({
     videos,
     playlists, // all playlists
-    selectedVideo,
+    selectedVideoId,
     currentPlaylist, // selected playlist / currently playing playlist
     onWatchedMark,
     onWatchedReset,
@@ -16,7 +16,7 @@ export default function VideoList({
                 <VideoListItem
                     key={video.id}
                     video={video}
-                    isSelected={selectedVideo?.id === video.id || currentPlaylist.some(v => v.id === video.id)}
+                    isSelected={selectedVideoId === video.id || currentPlaylist.some(v => v.id === video.id)}
                     videoCountVisible
                     playlistVideos={playlists.find(p => p.some(pv => pv.id === video.id)) ?? null}
                     onWatchedMark={onWatchedMark}

--- a/frontend/src/components/frontend/VideoList/VideoList.jsx
+++ b/frontend/src/components/frontend/VideoList/VideoList.jsx
@@ -5,6 +5,7 @@ export default function VideoList({
     playlists, // all playlists
     selectedVideoId,
     currentPlaylist, // selected playlist / currently playing playlist
+    currentQuality,
     onWatchedMark,
     onWatchedReset,
     onDelete }) {
@@ -19,6 +20,7 @@ export default function VideoList({
                     isSelected={selectedVideoId === video.id || currentPlaylist.some(v => v.id === video.id)}
                     videoCountVisible
                     playlistVideos={playlists.find(p => p.some(pv => pv.id === video.id)) ?? null}
+                    currentQuality={currentQuality}
                     onWatchedMark={onWatchedMark}
                     onWatchedReset={onWatchedReset}
                     onDelete={onDelete}

--- a/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItem.jsx
@@ -4,13 +4,27 @@ import VideoListItemThumbnail from './VideoListItemThumbnail'
 import VideoListItemInfo from './VideoListItemInfo'
 import { videoLink, isFullyWatched } from '@/lib/video'
 
-function getTargetLink(video, playlistVideos) {
-    if (!playlistVideos) return videoLink(video)
-    const target = playlistVideos.find(v => !isFullyWatched(v)) ?? playlistVideos[playlistVideos.length - 1]
+function getTargetLink(video, playlistVideos, currentQuality) {
+    const target = playlistVideos
+        ? (playlistVideos.find(v => !isFullyWatched(v)) ?? playlistVideos[playlistVideos.length - 1])
+        : video
+    if (currentQuality && currentQuality !== 'original') {
+        const version = target.versions?.find(v => v.quality === currentQuality)
+        if (version) return target.savedTime ? `/watch/${version.id}?t=${target.savedTime}` : `/watch/${version.id}`
+    }
     return videoLink(target)
 }
 
-export default function VideoListItem({ video, isSelected, videoCountVisible, onWatchedReset, onWatchedMark, onDelete, playlistVideos }) {
+export default function VideoListItem({
+    video,
+    isSelected,
+    videoCountVisible,
+    onWatchedReset,
+    onWatchedMark,
+    onDelete,
+    playlistVideos,
+    currentQuality
+}) {
 
     const progressSavedTime = playlistVideos
         ? playlistVideos.reduce((sum, v) => sum + (parseFloat(v.savedTime) || 0), 0)
@@ -22,7 +36,7 @@ export default function VideoListItem({ video, isSelected, videoCountVisible, on
     return (
         <div className={`flex items-center p-2 hover:bg-gray-100 ${isSelected ? 'bg-gray-200' : ''}`}>
             <Link
-                to={getTargetLink(video, playlistVideos)}
+                to={getTargetLink(video, playlistVideos, currentQuality)}
                 title={video.name}
                 className="flex gap-2 min-w-0 flex-1"
             >

--- a/frontend/src/components/frontend/VideoListItem/VideoListItemMenu.jsx
+++ b/frontend/src/components/frontend/VideoListItem/VideoListItemMenu.jsx
@@ -15,7 +15,7 @@ export default function VideoListItemMenu({ video, onWatchedMark, onWatchedReset
             <DropdownMenuTrigger className="rounded hover:bg-gray-200 flex-shrink-0 cursor-pointer">
                 <EllipsisVertical className="w-4 h-4 text-gray-500" />
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-45">
+            <DropdownMenuContent align="end" className="min-w-50">
                 <DropdownMenuItem disabled={video.status !== 'Ready'}>
                     <a
                         href={`${API_URL}/download/${video.id}`}
@@ -23,7 +23,7 @@ export default function VideoListItemMenu({ video, onWatchedMark, onWatchedReset
                         className="w-full flex items-center gap-2"
                     >
                         <Download className="w-4 h-4 shrink-0" />
-                        Download Max
+                        Download Original
                     </a>
                 </DropdownMenuItem>
                 {[...(video.versions ?? [])].sort((a, b) => (parseInt(b.quality) || 0) - (parseInt(a.quality) || 0)).map(v => (

--- a/frontend/src/components/frontend/VideoPlayer/VideoPlayer.jsx
+++ b/frontend/src/components/frontend/VideoPlayer/VideoPlayer.jsx
@@ -1,9 +1,10 @@
 import { forwardRef } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams, useParams } from 'react-router-dom'
 import { VIDEO_SAVE_INTERVAL } from '@/lib/video'
 
 const VideoPlayer = forwardRef(function VideoPlayer({ video, onVideoUpdated }, ref) {
     const [searchParams, setSearchParams] = useSearchParams()
+    const { id } = useParams()
 
     function saveWatchedTime(t) {
         localStorage.setItem(`time_${video.id}`, t)
@@ -15,8 +16,8 @@ const VideoPlayer = forwardRef(function VideoPlayer({ video, onVideoUpdated }, r
     return (
         <video
             ref={ref}
-            key={video.id}
-            src={`${import.meta.env.VITE_API_URL}/video/${video.id}`}
+            key={id}
+            src={`${import.meta.env.VITE_API_URL}/video/${id}`}
             controls
             autoPlay
             playsInline

--- a/frontend/src/components/ui/badge.jsx
+++ b/frontend/src/components/ui/badge.jsx
@@ -1,0 +1,49 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps({
+      className: cn(badgeVariants({ variant }), className),
+    }, props),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  });
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/hooks/frontend/useVideoNavigation.js
+++ b/frontend/src/hooks/frontend/useVideoNavigation.js
@@ -1,9 +1,10 @@
 import { useEffect } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams, useParams } from 'react-router-dom'
 
-export function useVideoNavigation(id, videos, playlists, versionToVideoId) {
+export function useVideoNavigation(videos, playlists, versionToVideoId) {
     const navigate = useNavigate()
     const [searchParams] = useSearchParams()
+    const { id } = useParams()
 
     useEffect(() => {
         if (!id || (videos.length > 0 && !versionToVideoId[id])) {

--- a/frontend/src/hooks/frontend/useVideoNavigation.js
+++ b/frontend/src/hooks/frontend/useVideoNavigation.js
@@ -1,12 +1,12 @@
 import { useEffect } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
-export function useVideoNavigation(id, videos, playlists) {
+export function useVideoNavigation(id, videos, playlists, versionToVideoId) {
     const navigate = useNavigate()
     const [searchParams] = useSearchParams()
 
     useEffect(() => {
-        if (!id || (videos.length > 0 && !videos.find(v => v.id === id))) {
+        if (!id || (videos.length > 0 && !versionToVideoId[id])) {
             const firstVideo = videos[0]
             if (firstVideo) {
                 const playlist = playlists.find(p => p.some(v => v.id === firstVideo.id))
@@ -16,11 +16,12 @@ export function useVideoNavigation(id, videos, playlists) {
             return
         }
         if (!searchParams.get('t')) {
-            const savedTime = Math.floor(parseFloat(localStorage.getItem(`time_${id}`)))
+            const originalId = versionToVideoId[id] ?? id
+            const savedTime = Math.floor(parseFloat(localStorage.getItem(`time_${originalId}`)))
             if (savedTime && savedTime > 10) {
                 navigate(`/watch/${id}?t=${savedTime}`, { replace: true })
                 return
             }
         }
-    }, [id, videos, playlists])
+    }, [id, videos, playlists, versionToVideoId])
 }

--- a/frontend/src/hooks/frontend/useVideos.js
+++ b/frontend/src/hooks/frontend/useVideos.js
@@ -17,6 +17,17 @@ export function useVideos() {
         return map
     }, [videos])
 
+    const videoIdToQuality = useMemo(() => {
+        const map = {}
+        for (const v of videos) {
+            map[v.id] = 'original'
+            for (const version of v.versions ?? []) {
+                map[version.id] = version.quality
+            }
+        }
+        return map
+    }, [videos])
+
     useEffect(() => {
         (async () => {
             const res = await fetch(`${API_URL}/videos`)
@@ -59,5 +70,5 @@ export function useVideos() {
         })()
     }, [])
 
-    return { videos, setVideos, playlists, versionToVideoId }
+    return { videos, setVideos, playlists, versionToVideoId, videoIdToQuality }
 }

--- a/frontend/src/hooks/frontend/useVideos.js
+++ b/frontend/src/hooks/frontend/useVideos.js
@@ -1,11 +1,21 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 
 const API_URL = import.meta.env.VITE_API_URL
 
 export function useVideos() {
     const [videos, setVideos] = useState([])
     const [playlists, setPlaylists] = useState([])
-    const [versionToVideoId, setVersionToVideoId] = useState({})
+
+    const versionToVideoId = useMemo(() => {
+        const map = {}
+        for (const v of videos) {
+            map[v.id] = v.id
+            for (const version of v.versions ?? []) {
+                map[version.id] = v.id
+            }
+        }
+        return map
+    }, [videos])
 
     useEffect(() => {
         (async () => {
@@ -37,17 +47,8 @@ export function useVideos() {
                     })
                 )
 
-            const versionToVideoId = {}
-            for (const v of videos) {
-                versionToVideoId[v.id] = v.id
-                for (const version of v.versions ?? []) {
-                    versionToVideoId[version.id] = v.id
-                }
-            }
-
             setPlaylists(playlistsArr)
             setVideos(videos)
-            setVersionToVideoId(versionToVideoId)
 
             Promise.allSettled(videos.map(async v => {
                 const res = await fetch(`${API_URL}/duration/${v.id}`)

--- a/frontend/src/hooks/frontend/useVideos.js
+++ b/frontend/src/hooks/frontend/useVideos.js
@@ -5,6 +5,7 @@ const API_URL = import.meta.env.VITE_API_URL
 export function useVideos() {
     const [videos, setVideos] = useState([])
     const [playlists, setPlaylists] = useState([])
+    const [versionToVideoId, setVersionToVideoId] = useState({})
 
     useEffect(() => {
         (async () => {
@@ -36,8 +37,17 @@ export function useVideos() {
                     })
                 )
 
+            const versionToVideoId = {}
+            for (const v of videos) {
+                versionToVideoId[v.id] = v.id
+                for (const version of v.versions ?? []) {
+                    versionToVideoId[version.id] = v.id
+                }
+            }
+
             setPlaylists(playlistsArr)
             setVideos(videos)
+            setVersionToVideoId(versionToVideoId)
 
             Promise.allSettled(videos.map(async v => {
                 const res = await fetch(`${API_URL}/duration/${v.id}`)
@@ -48,5 +58,5 @@ export function useVideos() {
         })()
     }, [])
 
-    return { videos, setVideos, playlists }
+    return { videos, setVideos, playlists, versionToVideoId }
 }

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -96,7 +96,7 @@ export default function Home() {
                             <VideoList
                                 videos={videos}
                                 playlists={playlists}
-                                selectedVideo={selectedVideo}
+                                selectedVideoId={selectedVideo?.id}
                                 currentPlaylist={currentPlaylist}
                                 onWatchedMark={handleWatchedMarkPlaylist}
                                 onWatchedReset={handleWatchedResetPlaylist}

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -22,11 +22,12 @@ import {
 
 export default function Home() {
     const { id } = useParams()
-    const { videos, setVideos, playlists, versionToVideoId } = useVideos()
+    const { videos, setVideos, playlists, versionToVideoId, videoIdToQuality } = useVideos()
     const videoRef = useRef(null)
     const videoDialogsRef = useRef(null)
 
     const selectedVideo = useMemo(() => videos.find(v => v.id === (versionToVideoId[id] ?? id)), [videos, id, versionToVideoId])
+    const currentQuality = videoIdToQuality[id]
     const currentPlaylist = useMemo(() => playlists.find(p => p.some(v => v.id === selectedVideo?.id)) ?? [], [playlists, selectedVideo])
 
     const {
@@ -87,6 +88,7 @@ export default function Home() {
                                 <PlaylistPanel
                                     currentPlaylist={currentPlaylist}
                                     selectedVideoId={selectedVideo?.id}
+                                    currentQuality={currentQuality}
                                     onWatchedReset={handleWatchedReset}
                                     onWatchedMark={handleWatchedMark}
                                     onDelete={handleDeleteSingle}
@@ -97,6 +99,7 @@ export default function Home() {
                                 playlists={playlists}
                                 selectedVideoId={selectedVideo?.id}
                                 currentPlaylist={currentPlaylist}
+                                currentQuality={currentQuality}
                                 onWatchedMark={handleWatchedMarkPlaylist}
                                 onWatchedReset={handleWatchedResetPlaylist}
                                 onDelete={handleDeletePlaylist}

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -34,7 +34,7 @@ export default function Home() {
         handleWatchedReset,
         handleWatchedMarkPlaylist,
         handleWatchedResetPlaylist
-    } = useWatchedTime(id, videoRef, setVideos, playlists)
+    } = useWatchedTime(selectedVideo?.id, videoRef, setVideos, playlists)
 
     const {
         handleDeleteSingle,
@@ -44,7 +44,7 @@ export default function Home() {
     useVideoKeyboard(videoRef)
     useVideoMetadata(selectedVideo)
 
-    useVideoNavigation(id, videos, playlists, versionToVideoId)
+    useVideoNavigation(videos, playlists, versionToVideoId)
 
     return (
         <SidebarProvider defaultOpen={false}>
@@ -72,7 +72,6 @@ export default function Home() {
                                     <VideoPlayer
                                         ref={videoRef}
                                         video={selectedVideo}
-                                        versionToVideoId={versionToVideoId}
                                         onVideoUpdated={() => setVideos(prev => [...prev])}
                                     />
                                 )}

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -22,11 +22,11 @@ import {
 
 export default function Home() {
     const { id } = useParams()
-    const { videos, setVideos, playlists } = useVideos()
+    const { videos, setVideos, playlists, versionToVideoId } = useVideos()
     const videoRef = useRef(null)
     const videoDialogsRef = useRef(null)
 
-    const selectedVideo = useMemo(() => videos.find(v => v.id === id), [videos, id])
+    const selectedVideo = useMemo(() => videos.find(v => v.id === (versionToVideoId[id] ?? id)), [videos, id, versionToVideoId])
     const currentPlaylist = useMemo(() => playlists.find(p => p.some(v => v.id === selectedVideo?.id)) ?? [], [playlists, selectedVideo])
 
     const {
@@ -44,7 +44,7 @@ export default function Home() {
     useVideoKeyboard(videoRef)
     useVideoMetadata(selectedVideo)
 
-    useVideoNavigation(id, videos, playlists)
+    useVideoNavigation(id, videos, playlists, versionToVideoId)
 
     return (
         <SidebarProvider defaultOpen={false}>
@@ -72,6 +72,7 @@ export default function Home() {
                                     <VideoPlayer
                                         ref={videoRef}
                                         video={selectedVideo}
+                                        versionToVideoId={versionToVideoId}
                                         onVideoUpdated={() => setVideos(prev => [...prev])}
                                     />
                                 )}


### PR DESCRIPTION
Closes #46

## Summary
- Add 480p/720p quality badges to VideoInfo; clicking navigates to the correct version URL with saved time preserved
- Backend serves video versions via the existing `/video/:id` endpoint
- Video list items and playlist panel navigate to the matching quality version when one is active
- Watched time is always saved against the original video id; `versionToVideoId` index (derived via `useMemo`) resolves versions to their original

## Test plan
- [x] Open a video that has 480p/720p versions — badges appear in VideoInfo
- [x] Click a quality badge — correct version plays, URL updates, time is preserved
- [x] Click original badge — original video plays
- [x] Clicking a video in the list while a version is active navigates to the matching quality version
- [x] Watched time (mark/reset) works correctly when a version is selected
- [x] Direct navigation to a version URL loads the correct video with saved time

🤖 Generated with [Claude Code](https://claude.com/claude-code)